### PR TITLE
Added reload and proxyconf to OL6/7

### DIFF
--- a/OracleLinux/6/README.md
+++ b/OracleLinux/6/README.md
@@ -8,12 +8,13 @@ A vagrant box that provisions Oracle Linux automatically, using Vagrant, an Orac
 ## Getting started
 1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
 2. cd vagrant-boxes/OracleLinux/6
-3. Run `vagrant up`
+3. Run `vagrant status` to check Vagrantfile status and possible plugin(s) required
+4. Run `vagrant up`
    1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection!
    2. The Vagrant file allows for customization.
-4. SSH into the VM either by using `vagrant ssh` 
+5. SSH into the VM either by using `vagrant ssh` 
    If required, by Vagrantfile you can also setup ssh port forwarding.
-5. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
+6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
 
 ## Other info
 

--- a/OracleLinux/6/Vagrantfile
+++ b/OracleLinux/6/Vagrantfile
@@ -19,6 +19,16 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "ol6-vagrant"
 
+unless Vagrant.has_plugin?("vagrant-reload")
+  puts 'Installing vagrant-reload Plugin...'
+  system('vagrant plugin install vagrant-reload')
+end
+
+unless Vagrant.has_plugin?("vagrant-proxyconf")
+  puts 'Installing vagrant-proxyconf Plugin...'
+  system('vagrant plugin install vagrant-proxyconf')
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol6-latest-box"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol6-latest.box"
@@ -31,6 +41,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.name = NAME
   end
 
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    puts "getting Proxy Configuration from Host..."
+    if ENV["http_proxy"]
+      puts "http_proxy: " + ENV["http_proxy"]
+      config.proxy.http     = ENV["http_proxy"]
+    end
+    if ENV["https_proxy"]
+      puts "https_proxy: " + ENV["https_proxy"]
+      config.proxy.https    = ENV["https_proxy"]
+    end
+    if ENV["no_proxy"]
+      config.proxy.no_proxy = ENV["no_proxy"]
+    end
+  end
+
   # VM hostname
   config.vm.hostname = NAME
   
@@ -39,5 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Provision everything on the first run
   config.vm.provision "shell", path: "scripts/install.sh"
+  config.vm.provision :reload
+  config.vm.provision "shell", inline: "echo 'INSTALLER: Installation complete, Oracle Linux 6 ready to use!'"
 
 end

--- a/OracleLinux/6/scripts/install.sh
+++ b/OracleLinux/6/scripts/install.sh
@@ -24,4 +24,4 @@ echo LC_ALL=en_US.utf-8 >> /etc/environment
 
 echo 'INSTALLER: Locale set'
 
-echo 'INSTALLER: Installation complete, Oracle Linux ready to use!'
+echo 'INSTALLER: Going to reboot to get updated system'

--- a/OracleLinux/7/README.md
+++ b/OracleLinux/7/README.md
@@ -8,12 +8,13 @@ A vagrant box that provisions Oracle Linux automatically, using Vagrant, an Orac
 ## Getting started
 1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
 2. cd vagrant-boxes/OracleLinux/7
-3. Run `vagrant up`
+3. Run `vagrant status` to check Vagrantfile status and possible plugin(s) required
+4. Run `vagrant up`
    1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection!
    2. The Vagrant file allows for customization.
-4. SSH into the VM either by using `vagrant ssh` 
+5. SSH into the VM either by using `vagrant ssh` 
    If required, by Vagrantfile you can also setup ssh port forwarding.
-5. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
+6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
 
 ## Other info
 

--- a/OracleLinux/7/Vagrantfile
+++ b/OracleLinux/7/Vagrantfile
@@ -19,6 +19,16 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "ol7-vagrant"
 
+unless Vagrant.has_plugin?("vagrant-reload")
+  puts 'Installing vagrant-reload Plugin...'
+  system('vagrant plugin install vagrant-reload')
+end
+
+unless Vagrant.has_plugin?("vagrant-proxyconf")
+  puts 'Installing vagrant-proxyconf Plugin...'
+  system('vagrant plugin install vagrant-proxyconf')
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest-box"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
@@ -31,6 +41,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.name = NAME
   end
 
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    puts "getting Proxy Configuration from Host..."
+    if ENV["http_proxy"]
+      puts "http_proxy: " + ENV["http_proxy"]
+      config.proxy.http     = ENV["http_proxy"]
+    end
+    if ENV["https_proxy"]
+      puts "https_proxy: " + ENV["https_proxy"]
+      config.proxy.https    = ENV["https_proxy"]
+    end
+    if ENV["no_proxy"]
+      config.proxy.no_proxy = ENV["no_proxy"]
+    end
+  end
+
   # VM hostname
   config.vm.hostname = NAME
   
@@ -39,5 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Provision everything on the first run
   config.vm.provision "shell", path: "scripts/install.sh"
+  config.vm.provision :reload
+  config.vm.provision "shell", inline: "echo 'INSTALLER: Installation complete, Oracle Linux 7 ready to use!'"
 
 end

--- a/OracleLinux/7/scripts/install.sh
+++ b/OracleLinux/7/scripts/install.sh
@@ -24,4 +24,4 @@ echo LC_ALL=en_US.utf-8 >> /etc/environment
 
 echo 'INSTALLER: Locale set'
 
-echo 'INSTALLER: Installation complete, Oracle Linux ready to use!'
+echo 'INSTALLER: Going to reboot to get updated system'


### PR DESCRIPTION
Added two plugins "vagrant-reload" and "vagrant-proxyconf" to both OL 6 and OL 7.
While proxyconf automatically manages the proxy configuration for Vagrant and VM, "reload" is required to get the VM rebooted once the updated kernel (and user-space stuff) has been installed during the provisioning process.