### PR TITLE
Consistent box name, used by vagrant for caching

### DIFF
--- a/DockerEngine/Vagrantfile
+++ b/DockerEngine/Vagrantfile
@@ -20,7 +20,7 @@ VAGRANTFILE_API_VERSION = "2"
 NAME = "ol7-docker-engine"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ol7-latest-box"
+  config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
   
   config.vm.box_check_update = false

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -56,7 +56,7 @@ MEMORY = 2048
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # We start from the latest OL 7 Box
-  config.vm.box = "ol7-latest-box"
+  config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
 
   # If we use the vagrant-proxyconf plugin, we should not proxy k8s/local IPs

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -20,7 +20,7 @@ VAGRANTFILE_API_VERSION = "2"
 NAME = "oracle11g-xe-vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ol7-latest-box"
+  config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
   
   config.vm.box_check_update = false

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -20,7 +20,7 @@ VAGRANTFILE_API_VERSION = "2"
 NAME = "oracle-12201-vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ol7-latest-box"
+  config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
   
   config.vm.box_check_update = false

--- a/OracleLinux/6/Vagrantfile
+++ b/OracleLinux/6/Vagrantfile
@@ -20,7 +20,7 @@ VAGRANTFILE_API_VERSION = "2"
 NAME = "ol6-vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ol6-latest-box"
+  config.vm.box = "ol6-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol6-latest.box"
   
   config.vm.box_check_update = false

--- a/OracleLinux/7/Vagrantfile
+++ b/OracleLinux/7/Vagrantfile
@@ -20,7 +20,7 @@ VAGRANTFILE_API_VERSION = "2"
 NAME = "ol7-vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ol7-latest-box"
+  config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
   
   config.vm.box_check_update = false


### PR DESCRIPTION
`config.vm.box` is used by vagrant to resolve the box file in the local cache. I.e if you use a different name, Vagrant will re-download the same box file again unnecessarily bloating the local cache.

The reason for dropping the "-box" is because of information redundancy. `config.vm.box` already makes it clear that it is a box.

Signed-off-by: Gerald Venzl <gerald.venzl@gmail.com>