### PR TITLE
RFC: Add vagrant to docker group

### DIFF
--- a/DockerEngine/scripts/install.sh
+++ b/DockerEngine/scripts/install.sh
@@ -24,10 +24,13 @@ docker-storage-config -s btrfs -d /dev/sdb
 systemctl start docker
 systemctl enable docker
 
+# Add vagrant user to docker group
+usermod -a -G docker vagrant
+
 echo 'Docker engine is ready to use'
 echo 'To get started, on your host, run:'
 echo '  vagrant ssh'
 echo 
 echo 'Then, within the guest (for example):'
-echo '  sudo docker run -it oraclelinux:6-slim'
+echo '  docker run -it oraclelinux:6-slim'
 echo


### PR DESCRIPTION
I like to have `vagrant` user part of the `docker` group, so you don't have to `sudo` every time.