### PR TITLE
Kubernetes: add USE_PREVIEW parameter

### DIFF
--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -31,10 +31,6 @@ Within the master guest you can check the status of the cluster (as the
 
 ## About the Vagrantfile
 
-The Vagrant provisioning script uses the _Oracle Linux 7 Preview_ and
-_Add-ons_ channels for both Docker Engine and Kubernetes (latest version is
-select by `yum`).
-
 The VMs communicate via a private network:
 
 - Master node: 192.168.99.100 / master.vagrant.vm
@@ -52,6 +48,10 @@ The Vagrantfile can be used _as-is_; there are a couple of parameters you
 can set to tailor the installation to your needs.
 
 - `NB_WORKERS` (default: 2): the number of worker nodes to provision.
+- `USE_PREVIEW` (default: `true`): when `true`, Vagrant provisioning script
+will use the _Oracle Linux 7 Preview_ and _Add-ons_ channels for both Docker
+Engine and Kubernetes (latest version is select by `yum`).  
+Otherwhise it will only use the _Add-ons_ channel.
 - `MANAGE_FROM_HOST` (default: `false`): when `true`, Vagrant will bind port
 `6443` from the master node to the host.
 This allows you to manage the cluster from the host itself using the generated

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -18,10 +18,6 @@
 #   - Master  : 192.168.99.100
 #   - Worker i: 192.168.99.(100+i)
 #
-# /!\ Uses the "technology preview" build of Docker / Kubernetes /!\
-# The script installs the latest version which can be either in 'addons'
-# or in 'preview' channel.
-#
 # The provisioning script only pre-loads k8s and satisfies pre-requisites.
 # When the VMs are provisioned run (as root):
 #    on master:
@@ -44,6 +40,8 @@ VAGRANTFILE_API_VERSION = "2"
 
 # Number of worker nodes to provision
 NB_WORKERS = 2
+# Use the "Preview" channel for both Docker Engine and Kubernetes
+USE_PREVIEW = true
 # To manage your cluster from the vagrant host, set the following variable
 # to true
 MANAGE_FROM_HOST = false
@@ -121,5 +119,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Provisioning: install Docker and Kubernetes
-  config.vm.provision "shell", path: "scripts/provision.sh"
+  config.vm.provision "shell",
+    path: "scripts/provision.sh",
+    args: USE_PREVIEW ? ["--preview"] : []
 end

--- a/Kubernetes/scripts/provision.sh
+++ b/Kubernetes/scripts/provision.sh
@@ -12,10 +12,28 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
+# YUM repo selection.
+YumRepos="--disablerepo=ol7_preview"
+
+# Parse arguments
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    "--preview")
+      YumRepos="--enablerepo=ol7_preview"
+      shift
+      ;;
+    *)
+      echo "Invalid parameter"
+      exit 1
+      ;;
+  esac
+done
+
 echo "Installing and configuring Docker Engine"
 
 # Install Docker
-yum install -y docker-engine btrfs-progs
+yum ${YumRepos} install -y docker-engine btrfs-progs
 
 # Create and mount a BTRFS partition for docker.
 docker-storage-config -f -s btrfs -d /dev/sdb
@@ -35,7 +53,7 @@ systemctl start docker
 echo "Installing and configuring Kubernetes packages"
 
 # Install Kubernetes packages from the "preview" channel fulfil pre-requisites
-yum --enablerepo ol7_preview install -y  kubeadm
+yum ${YumRepos} install -y  kubeadm
 # Set SeLinux to Permissive
 /usr/sbin/setenforce 0
 sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config


### PR DESCRIPTION
With `USE_PREVIEW` script parameter the user can decide to install the latest tech preview or the latest stable version.
Default value is `true` (consistent with current version)