### PR TITLE
Kuberentes; add support for Registry Mirrors / Local Registries

### DIFF
--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -13,11 +13,11 @@ _Container Services_ Business Area.
 1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
 1. Change into the `vagrant-boxes/Kubernetes` folder
 1. Run `vagrant up master; vagrant ssh master`
-1. Within the master guest, run as `root`:
+1. Within the master guest, run as `root`: <sup>[(\*)](#note-1)</sup>  
 `/vagrant/scripts/kubeadm-setup-master.sh`  
 You will be asked to log in to the Oracle Container Registry
 1. Run `vagrant up worker1; vagrant ssh worker1`
-1. Within the worker1 guest, run as `root`:
+1. Within the worker1 guest, run as `root`: <sup>[(\*)](#note-1)</sup>  
 `/vagrant/scripts/kubeadm-setup-worker.sh`  
 You will be asked to log in to the Oracle Container Registry
 1. Repeat the last 2 steps for worker2
@@ -29,6 +29,9 @@ Within the master guest you can check the status of the cluster (as the
 - `kubectl get nodes`
 - `kubectl get pods --namespace=kube-system`
 
+<a id="note-1"></a>(\*) If you have a password-less local container registry
+skip steps 4 and 6  (see [Local Registry](#local-registry)).
+
 ## About the Vagrantfile
 
 The VMs communicate via a private network:
@@ -38,7 +41,8 @@ The VMs communicate via a private network:
 
 The Vagrant provisioning script pre-loads Kubernetes and satisfies the
 pre-requisites.
-It does **not** run `kubeadm-setup.sh` as this requires authentication to the
+Unless you have a password-less [Local Registry](#local-registry) it does
+**not** run `kubeadm-setup.sh` as this requires authentication to the
 [Oracle Container Registry](https://container-registry.oracle.com). This is
 done by the `kubeadm-setup-master.sh` and `kubeadm-setup-worker.sh` helper
 scripts.
@@ -66,8 +70,14 @@ can be slightly reduced if memory is a concern.
 ### Registry Mirror
 If you are using an [Oracle Container Registry Mirror](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-mirror.html)
 you can use the following two parameters:
-- `KUBE_REPO`: registry hostname (e.g.: `container-registry-ash.oracle.com`)
-- `KUBE_PREFIX`: image prefix (e.g.: `/kubernetes`)
+- `KUBE_REPO`: registry hostname
+- `KUBE_PREFIX`: image prefix for Kubernetes container images
+
+__Example__: to use the Oracle Container Registry mirror in Frankfurt, define
+```ruby
+KUBE_REPO = "container-registry-fra.oracle.com"
+KUBE_PREFIX = "/kubernetes"
+```
 
 ### Local Registry
 You can also setup a [Local Registry](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-local.html).
@@ -76,6 +86,18 @@ In addition to the `KUBE_REPO` and `KUBE_PREFIX` parameters you can also define:
 does not require authentication.
 - `KUBE_SSL` (default: `undefined`/`true`): set to `false` if your registry
 does not use SSL.
+
+__Example__: you have a local repository on host.example.com, without authentication and SSL is not configured; this registry has been populated with:
+```shell
+kubeadm-registry.sh --to host.example.com:5000/kubernetes --version 1.9.1
+```
+You will then define in tour Vagrantfile:
+```ruby
+KUBE_REPO = "host.example.com:5000"
+KUBE_PREFIX = "/kubernetes"
+KUBE_LOGIN = false
+KUBE_SSL = false
+```
 
 __Note__: if you have a password-less registry (`KUBE_LOGIN = false`) the
 Vagrant provisioning script will also run the `kubeadm-setup-master.sh` / `kubeadm-setup-worker.sh` scripts. In other words, your Kubernetes

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -63,6 +63,24 @@ It is an easier alternative to ssh tunnel.
 - `MEMORY` (default: 2048): all VMs are provisioned with 2GB memory. This
 can be slightly reduced if memory is a concern.
 
+### Registry Mirror
+If you are using an [Oracle Container Registry Mirror](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-mirror.html)
+you can use the following two parameters:
+- `KUBE_REPO`: registry hostname (e.g.: `container-registry-ash.oracle.com`)
+- `KUBE_PREFIX`: image prefix (e.g.: `/kubernetes`)
+
+### Local Registry
+You can also setup a [Local Registry](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-local.html).
+In addition to the `KUBE_REPO` and `KUBE_PREFIX` parameters you can also define:
+- `KUBE_LOGIN` (default: `undefined`/`true`): set to `false` if your registry
+does not require authentication.
+- `KUBE_SSL` (default: `undefined`/`true`): set to `false` if your registry
+does not use SSL.
+
+__Note__: if you have a password-less registry (`KUBE_LOGIN = false`) the
+Vagrant provisioning script will also run the `kubeadm-setup-master.sh` / `kubeadm-setup-worker.sh` scripts. In other words, your Kubernetes
+cluster will be fully operational after a `vagrant up`!
+
 ## Optional plugins
 You might want to install the following Vagrant plugins:
 - [vagrant-hosts](https://github.com/oscar-stack/vagrant-hosts): maintains

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -18,7 +18,8 @@
 #   - Master  : 192.168.99.100
 #   - Worker i: 192.168.99.(100+i)
 #
-# The provisioning script only pre-loads k8s and satisfies pre-requisites.
+# Unless you have a paswordless local registry (see below) the provisioning
+# script only pre-loads k8s and satisfies pre-requisites.
 # When the VMs are provisioned run (as root):
 #    on master:
 #        /vagrant/scripts/kubeadm-setup-master.sh
@@ -50,15 +51,33 @@ MANAGE_FROM_HOST = false
 BIND_PROXY = true
 # Memory for the VMs (2GB)
 MEMORY = 2048
+
 # Local Registry configuration -- Use the following parameters if you have
 # configured a Local Registry
 # Repository and prefix - e.g. for local-registry.example.com:5000/kubernetes:
 # KUBE_REPO = "local-registry.example.com:5000"
 # KUBE_PREFIX = "/kubernetes"
-# Does the registry requires login?
+# Does the registry requires login? If no login is required, the provisioning
+# script will be able to run kubadm-setup on all nodes!
 # KUBE_LOGIN = false
-# Does the registry uses SSL?
+# Does the registry use SSL?
 # KUBE_SSL = false
+
+def setup_local_repo (node, vm)
+  if defined? KUBE_REPO
+    registry = KUBE_REPO + ((defined? KUBE_PREFIX) ? KUBE_PREFIX : "")
+    vm.provision :shell, inline: <<-SHELL
+	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~/.bashrc
+    SHELL
+    if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
+      # If registry login is not required, we can run kubeadm
+      vm.provision "shell",
+        path: "scripts/kubeadm-setup-#{node}.sh",
+        args: ["--no-login"],
+        env: {"KUBE_REPO_PREFIX" => "#{registry}"}
+    end
+  end
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -114,18 +133,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	systemctl daemon-reload
       SHELL
     end
-    if defined? KUBE_REPO
-      master.vm.provision :shell, inline: <<-SHELL
-	echo 'export KUBE_REPO_PREFIX="#{KUBE_REPO}#{KUBE_PREFIX}"' >> ~/.bashrc
-      SHELL
-    end
-    if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
-      # If registry login is not required, we can run kubeadm
-      master.vm.provision "shell",
-        path: "scripts/kubeadm-setup-master.sh",
-        args: ["--no-login"],
-        env: {"KUBE_REPO_PREFIX" => "#{KUBE_REPO}#{KUBE_PREFIX}"}
-    end
+    setup_local_repo("master", master.vm)
   end
   # - Workers
   (1..NB_WORKERS).each do |i|
@@ -136,18 +144,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true
       end
-      if defined? KUBE_REPO
-        worker.vm.provision :shell, inline: <<-SHELL
-	  echo 'export KUBE_REPO_PREFIX="#{KUBE_REPO}#{KUBE_PREFIX}"' >> ~/.bashrc
-        SHELL
-      end
-      if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
-        # If registry login is not required, we can run kubeadm
-        worker.vm.provision "shell",
-          path: "scripts/kubeadm-setup-worker.sh",
-          args: ["--no-login"],
-          env: {"KUBE_REPO_PREFIX" => "#{KUBE_REPO}#{KUBE_PREFIX}"}
-      end
+      setup_local_repo("worker", worker.vm)
     end
   end
 

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -68,6 +68,7 @@ def setup_local_repo (node, vm)
     registry = KUBE_REPO + ((defined? KUBE_PREFIX) ? KUBE_PREFIX : "")
     vm.provision :shell, inline: <<-SHELL
 	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~/.bashrc
+	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~vagrant/.bashrc
     SHELL
     if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
       # If registry login is not required, we can run kubeadm

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -50,6 +50,15 @@ MANAGE_FROM_HOST = false
 BIND_PROXY = true
 # Memory for the VMs (2GB)
 MEMORY = 2048
+# Local Registry configuration -- Use the following parameters if you have
+# configured a Local Registry
+# Repository and prefix - e.g. for local-registry.example.com:5000/kubernetes:
+# KUBE_REPO = "local-registry.example.com:5000"
+# KUBE_PREFIX = "/kubernetes"
+# Does the registry requires login?
+# KUBE_LOGIN = false
+# Does the registry uses SSL?
+# KUBE_SSL = false
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -105,6 +114,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	systemctl daemon-reload
       SHELL
     end
+    if defined? KUBE_REPO
+      master.vm.provision :shell, inline: <<-SHELL
+	echo 'export KUBE_REPO_PREFIX="#{KUBE_REPO}#{KUBE_PREFIX}"' >> ~/.bashrc
+      SHELL
+    end
+    if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
+      # If registry login is not required, we can run kubeadm
+      master.vm.provision "shell",
+        path: "scripts/kubeadm-setup-master.sh",
+        args: ["--no-login"],
+        env: {"KUBE_REPO_PREFIX" => "#{KUBE_REPO}#{KUBE_PREFIX}"}
+    end
   end
   # - Workers
   (1..NB_WORKERS).each do |i|
@@ -115,11 +136,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true
       end
+      if defined? KUBE_REPO
+        worker.vm.provision :shell, inline: <<-SHELL
+	  echo 'export KUBE_REPO_PREFIX="#{KUBE_REPO}#{KUBE_PREFIX}"' >> ~/.bashrc
+        SHELL
+      end
+      if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
+        # If registry login is not required, we can run kubeadm
+        worker.vm.provision "shell",
+          path: "scripts/kubeadm-setup-worker.sh",
+          args: ["--no-login"],
+          env: {"KUBE_REPO_PREFIX" => "#{KUBE_REPO}#{KUBE_PREFIX}"}
+      end
     end
   end
 
   # Provisioning: install Docker and Kubernetes
+  args = []
+  args.push("--preview") if USE_PREVIEW
+  args.push("--insecure", KUBE_REPO) if (defined? KUBE_SSL) && ! KUBE_SSL
   config.vm.provision "shell",
     path: "scripts/provision.sh",
-    args: USE_PREVIEW ? ["--preview"] : []
+    args: args
 end

--- a/Kubernetes/scripts/kubeadm-setup-master.sh
+++ b/Kubernetes/scripts/kubeadm-setup-master.sh
@@ -39,6 +39,12 @@ then
   exit 1
 fi
 
+if [ "$0" = "${SUDO_COMMAND%% *}" ]
+then
+  echo "$0: This script should not be called directly with 'sudo'"
+  exit 1
+fi
+
 if [ -z "${NoLogin}" ]
 then
   echo "$0: Login to ${Registry}"

--- a/Kubernetes/scripts/kubeadm-setup-master.sh
+++ b/Kubernetes/scripts/kubeadm-setup-master.sh
@@ -13,6 +13,25 @@
 #
 
 JoinCommand="/vagrant/join-command.sh"
+LogFile="kubeadm-setup.log"
+Registry="${KUBE_REPO_PREFIX:-container-registry.oracle.com}"
+Registry="${Registry%%/*}"
+NoLogin=""
+
+# Parse arguments
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    "--no-login")
+      NoLogin=1
+      shift
+      ;;
+    *)
+      echo "Invalid parameter"
+      exit 1
+      ;;
+  esac
+done
 
 if [ ${EUID} -ne 0 ]
 then
@@ -20,16 +39,27 @@ then
   exit 1
 fi
 
-echo "$0: Login to container registry"
-docker login container-registry.oracle.com
-if [ $? -ne 0 ]
+if [ -z "${NoLogin}" ]
 then
-  echo "$0: Authentication failure"
-  exit 1
+  echo "$0: Login to ${Registry}"
+  docker login ${Registry}
+  if [ $? -ne 0 ]
+  then
+    echo "$0: Authentication failure"
+    exit 1
+  fi
 fi
 
-echo "$0: Setup Master node"
-kubeadm-setup.sh up
+echo "$0: Setup Master node -- be patient!"
+kubeadm-setup.sh up > "${LogFile}" 2>&1
+
+if [ $? -ne 0 ]
+then
+  echo "$0: kubeadm-setup.sh did not complete successfully"
+  echo "Last lines of ${LogFile}:"
+  tail -10 "${LogFile}"
+  exit 1
+fi
 
 echo "$0: Copying admin.conf for vagrant user"
 mkdir -p ~vagrant/.kube

--- a/Kubernetes/scripts/kubeadm-setup-worker.sh
+++ b/Kubernetes/scripts/kubeadm-setup-worker.sh
@@ -12,6 +12,25 @@
 #
 
 JoinCommand="/vagrant/join-command.sh"
+LogFile="kubeadm-setup.log"
+Registry="${KUBE_REPO_PREFIX:-container-registry.oracle.com}"
+Registry="${Registry%%/*}"
+NoLogin=""
+
+# Parse arguments
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    "--no-login")
+      NoLogin=1
+      shift
+      ;;
+    *)
+     echo "$0: Invalid parameter"
+     exit 1
+     ;;
+  esac
+done
 
 if [ ${EUID} -ne 0 ]
 then
@@ -25,12 +44,15 @@ then
   exit 1
 fi
 
-echo "$0: Login to container registry"
-docker login container-registry.oracle.com
-if [ $? -ne 0 ]
+if [ -z "${NoLogin}" ]
 then
-  echo "$0: Authentication failure"
-  exit 1
+  echo "$0: Login to ${Registry}"
+  docker login ${Registry}
+  if [ $? -ne 0 ]
+  then
+    echo "$0: Authentication failure"
+    exit 1
+  fi
 fi
 
 echo "$0: Setup Worker node"

--- a/Kubernetes/scripts/kubeadm-setup-worker.sh
+++ b/Kubernetes/scripts/kubeadm-setup-worker.sh
@@ -38,6 +38,12 @@ then
   exit 1
 fi
 
+if [ "$0" = "${SUDO_COMMAND%% *}" ]
+then
+  echo "$0: This script should not be called directly with 'sudo'"
+  exit 1
+fi
+
 if [ ! -f "${JoinCommand}" ]
 then
   echo "$0: Token not found. Is the master already configured?"

--- a/Kubernetes/scripts/provision.sh
+++ b/Kubernetes/scripts/provision.sh
@@ -14,6 +14,7 @@
 
 # YUM repo selection.
 YumRepos="--disablerepo=ol7_preview"
+Insecure=""
 
 # Parse arguments
 while [ $# -gt 0 ]
@@ -22,6 +23,15 @@ do
     "--preview")
       YumRepos="--enablerepo=ol7_preview"
       shift
+      ;;
+    "--insecure")
+      if [ $# -lt 2 ]
+      then
+        echo "Missing parameter"
+	exit 1
+      fi
+      Insecure="$2"
+      shift; shift
       ;;
     *)
       echo "Invalid parameter"
@@ -42,6 +52,12 @@ docker-storage-config -f -s btrfs -d /dev/sdb
 # Alternatively you could use firewalld as described in the Kubernetes User's Guide
 # On the ol74 box, firewalld is installed but disabled by default.
 sed -i "s/^OPTIONS='\(.*\)'/OPTIONS='\1 --iptables=false'/" /etc/sysconfig/docker
+
+# Configure insecure (non-ssl) registry if needed
+if [ -n "${Insecure}" ]
+then
+  sed -i "s/\"$/\",\n    \"insecure-registries\": [\"${Insecure}\"]/" /etc/docker/daemon.json
+fi
 
 # Add vagrant user to docker group
 usermod -a -G docker vagrant


### PR DESCRIPTION
Add support for [Oracle Container Registry Mirror](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-mirror.html) and [Local Registry](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-local.html).  
Using a Registry Mirror in your region or a Local Registry improves provisioning speed.