### PR TITLE
Set name for all vagrant images (#39)

### DIFF
--- a/DockerEngine/Vagrantfile
+++ b/DockerEngine/Vagrantfile
@@ -22,6 +22,7 @@ NAME = "ol7-docker-engine"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
   
   config.vm.box_check_update = false
   

--- a/LAMP/Vagrantfile
+++ b/LAMP/Vagrantfile
@@ -32,6 +32,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
   
   config.vm.box_check_update = false
   

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -22,6 +22,7 @@ NAME = "oracle11g-xe-vagrant"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
   
   config.vm.box_check_update = false
   

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -22,6 +22,7 @@ NAME = "oracle-12201-vagrant"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
   
   config.vm.box_check_update = false
   

--- a/OracleLinux/preview/Vagrantfile
+++ b/OracleLinux/preview/Vagrantfile
@@ -32,6 +32,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
   
   config.vm.box_check_update = false
   


### PR DESCRIPTION
This addresses the enhancement in issue #39.

The resolution for issue #31 added `config.vm.define NAME` to the Vagrantfiles for the OracleLinux 6 and OracleLinux 7 boxes, so that Vagrant identifies the VM using the NAME variable, instead of "default", during vagrant up/suspend/halt/destroy/status operations.  This pull request adds the same to the remaining boxes (except for the Kubernetes box, which is already compliant, per @AmedeeBulle).

To validate, `cd` to the directory with the Vagrantfile and run `vagrant status`.  It isn't necessary to actually create the box.  Vagrant should identify the boxes as follows:

- DockerEngine:  "ol7-docker-engine"
- LAMP:  "ol7-lamp"
- OracleDatabase 11.2.0.2:  "oracle11g-xe-vagrant"
- OracleDatabase 12.2.0.1:  "oracle-12201-vagrant"
- OracleLinux preview:  "uek5-preview"