### PR TITLE
New Vagrantfile: local Container Registry

### DIFF
--- a/ContainerRegistry/README.md
+++ b/ContainerRegistry/README.md
@@ -1,0 +1,68 @@
+# Vagrantfile to run a Container Registry on Oracle Linux 7
+This simple Vagrantfile will provision an Oracle Linux 7 box running a local
+Container Registry.
+
+It can be used as cache for the Oracle Container Registry, in particular for
+the Kubernetes containers.
+
+## Prerequisites
+1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+1. Install [Vagrant](https://vagrantup.com/)
+1. Sign in to [Oracle Container Registry](https://container-registry.oracle.com)
+and accept the _Oracle Standard Terms and Restrictions_ for the
+_Container Services_ Business Area.
+
+## Quick start
+1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
+1. Change into the `vagrant-boxes/ContainerRegistry` folder
+1. Run `vagrant up; vagrant ssh`
+
+Your local container registry is up and running!
+
+## Configuration
+The Vagrantfile can be used _as-is_; there are a couple of parameters you
+can set to tailor the installation to your needs.
+
+- `REGISTRY_IP` (default: 192.168.99.253): the VM will join the VirtualBox
+private network using this IP.
+- `REGISTRY_BIND` (default: undefined): if this variable is defined, Vagrant
+will bind the registry port (5000) from the VM to the specified port on the
+host, making the local registry available outside of the Vagrant environment.
+
+### Use case: Registry Mirror for Kubernetes
+We can use our local container registry to mirror the Kubernetes containers
+for a faster deployment of a [Vagrant] Kubernetes cluster.  
+The `scripts` directory contains the `kubeadm-setup-registry.sh` convenience
+script for this task.
+
+1. `vagrant ssh` in your registry VM
+1. as `vagrant` user run:  
+`/vagrant/scripts/kubeadm-setup-registry.sh`  
+You will be asked to log in to the Oracle Container Registry.  
+If you want to mirror from an [Oracle Container Registry Mirror](https://docs.oracle.com/cd/E52668_01/E88884/html/requirements-registry-mirror.html), use the `--from` parameter, e.g.:  
+`/vagrant/scripts/kubeadm-setup-registry.sh --from container-registry-fra.oracle.com`
+
+To use this local registry with the [Vagrant Kubernetes cluster](../Kubernetes),
+define in the Kubernetes Vagrantfile:
+
+```ruby
+KUBE_REPO = "192.168.99.253:5000"
+KUBE_PREFIX = "/kubernetes"
+KUBE_LOGIN = false
+KUBE_SSL = false
+```
+
+With our local registry there is no need anymore to provide
+credentials when installing Kubernetes.
+Vagrant provisioning script will also run the `kubeadm-setup-master.sh` /
+`kubeadm-setup-worker.sh` scripts. In other words, your Kubernetes
+cluster will be fully operational after a `vagrant up`!
+
+## Optional plugins
+You might want to install the following Vagrant plugin:
+- [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VMs if you need to access Internet through proxy. See
+plugin documentation for the configuration.
+
+## Feedback
+Please provide feedback of any kind via Github issues on this repository.

--- a/ContainerRegistry/README.md
+++ b/ContainerRegistry/README.md
@@ -1,4 +1,4 @@
-# Vagrantfile to run a Container Registry on Oracle Linux 7
+# Vagrantfile to run a local Container Registry on Oracle Linux 7
 This simple Vagrantfile will provision an Oracle Linux 7 box running a local
 Container Registry.
 

--- a/ContainerRegistry/Vagrantfile
+++ b/ContainerRegistry/Vagrantfile
@@ -1,0 +1,95 @@
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: June, 2018
+# Author: philippe.vanhaesendonck@oracle.com
+# Description: Installs Docker Engine and setup Kubernetes cluster
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This simple Vagrantfile runs a Docker Registry in an OL7 guest
+# No SSL setup is done, this host needs to be added as "insecure-registries"
+# on the client systems
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Hostname
+NAME = "registry"
+
+# Registry IP on the private VirtualBox lan
+REGISTRY_IP = "192.168.99.253"
+# Bind registry port to host port
+# REGISTRY_BIND = 5000
+# Memory for the VMs (Registry doesn't require much)
+MEMORY = 1024
+
+def ensure_scheme(url)
+  (url =~ /.*:\/\// ? '' : 'http://') + url
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # We start from the latest OL 7 Box
+  config.vm.box = "ol7-latest"
+  config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
+
+  # If we use the vagrant-proxyconf plugin, we should not proxy k8s/local IPs
+  # Unfortunately we can't use CIDR with no_proxy, so we have to enumerate and
+  # 'blacklist' *all* IPs
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        puts "HTTP proxy: " + proxy
+        config.proxy.http = ensure_scheme(proxy)
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        puts "HTTPS proxy: " + proxy
+        config.proxy.https = ensure_scheme(proxy)
+        break
+      end
+    end
+
+    no_proxy = ''
+    ["no_proxy", "NO_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        no_proxy = ENV[proxy_var]
+        puts "No proxy: " + no_proxy
+        no_proxy += ','
+        break
+      end
+    end
+    config.proxy.no_proxy = no_proxy + "localhost,.vagrant.vm," + (".0"..".255").to_a.join(",")
+  end
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = MEMORY
+  end
+
+  config.vm.hostname = NAME + ".vagrant.vm"
+  config.vm.network "private_network", ip: REGISTRY_IP
+  if Vagrant.has_plugin?("vagrant-hosts")
+    config.vm.provision :hosts, :sync_hosts => true
+  end
+
+  if defined? REGISTRY_BIND
+    # Bind registry port to host port
+    config.vm.network "forwarded_port", guest: 5000, host: REGISTRY_BIND
+  end
+
+  # Provisioning: install Docker and run registry
+  config.vm.provision "shell",
+    path: "scripts/provision.sh"
+end

--- a/ContainerRegistry/scripts/kubeadm-setup-registry.sh
+++ b/ContainerRegistry/scripts/kubeadm-setup-registry.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: June, 2018
+# Author: philippe.vanhaesendonck@oracle.com
+# Description: Clone latest Kubernetes containers
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+Registry="container-registry.oracle.com"
+
+# Parse arguments
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    "--from")
+      if [ $# -lt 2 ]
+      then
+	echo "$0: Missing parameter"
+	exit 1
+      fi
+      Registry="$2"
+      shift; shift
+      ;;
+    *)
+      echo "$0: Invalid parameter"
+      exit 1
+      ;;
+  esac
+done
+
+echo "$0: Login to ${Registry}"
+docker login ${Registry}
+if [ $? -ne 0 ]
+then
+  echo "$0: Authentication failure"
+  exit 1
+fi
+
+echo "$0: Installing kubeadm"
+sudo yum install -y kubeadm
+
+echo "$0: Cloning Kubernetes containers"
+/bin/kubeadm-registry.sh --to localhost:5000/kubernetes --from ${Registry}/kubernetes
+
+echo "$0: Clone complete!"

--- a/ContainerRegistry/scripts/provision.sh
+++ b/ContainerRegistry/scripts/provision.sh
@@ -34,4 +34,4 @@ docker run \
         --publish 5000:5000 \
         registry:2
 
-echo "Your Resgitry VM is ready to use!"
+echo "Your Registry VM is ready to use!"

--- a/ContainerRegistry/scripts/provision.sh
+++ b/ContainerRegistry/scripts/provision.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: March, 2018
+# Author: philippe.vanhaesendonck@oracle.com
+# Description: Installs Docker Engine and runs a registry container
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+echo "Installing and configuring Docker Engine"
+
+# Install Docker
+yum install -y docker-engine btrfs-progs
+
+# Create and mount a BTRFS partition for docker.
+docker-storage-config -f -s btrfs -d /dev/sdb
+
+# Add vagrant user to docker group
+usermod -a -G docker vagrant
+
+# Enable and start Docker
+systemctl enable docker
+systemctl start docker
+
+echo "Run docker registry"
+docker run \
+        --detach \
+        --restart unless-stopped \
+        --name registry \
+        --publish 5000:5000 \
+        registry:2
+
+echo "Your Resgitry VM is ready to use!"

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -103,6 +103,9 @@ __Note__: if you have a password-less registry (`KUBE_LOGIN = false`) the
 Vagrant provisioning script will also run the `kubeadm-setup-master.sh` / `kubeadm-setup-worker.sh` scripts. In other words, your Kubernetes
 cluster will be fully operational after a `vagrant up`!
 
+See also the [Container Registry Vagrantfile](../ContainerRegistry) to run a
+local registry in Vagrant.
+
 ## Optional plugins
 You might want to install the following Vagrant plugins:
 - [vagrant-hosts](https://github.com/oscar-stack/vagrant-hosts): maintains


### PR DESCRIPTION
This is a new simple Vagrantfile providing a local Container Registry

It is mainly a companion Box for the Kubernetes Vagrantfile to allow local caching of the Kubernetes containers, but it can be used for any other purpose.