### PR TITLE
Remove Database 11.2.0.2 box installer directory (#50)

### DIFF
--- a/OracleDatabase/11.2.0.2/scripts/install.sh
+++ b/OracleDatabase/11.2.0.2/scripts/install.sh
@@ -34,6 +34,7 @@ echo 'INSTALLER: Oracle directories created'
 # install Oracle
 unzip /vagrant/oracle-xe-11.2.0-1.0.x86_64.rpm.zip -d /vagrant && \
 sudo rpm -i /vagrant/Disk1/oracle-xe-11.2.0-1.0.x86_64.rpm && \
+chmod -R o+w /vagrant/Disk1 && \
 rm -rf /vagrant/Disk1 && \
 sudo ln -s /u01/app/oracle /opt/oracle
 

--- a/OracleDatabase/11.2.0.2/scripts/install.sh
+++ b/OracleDatabase/11.2.0.2/scripts/install.sh
@@ -34,7 +34,7 @@ echo 'INSTALLER: Oracle directories created'
 # install Oracle
 unzip /vagrant/oracle-xe-11.2.0-1.0.x86_64.rpm.zip -d /vagrant && \
 sudo rpm -i /vagrant/Disk1/oracle-xe-11.2.0-1.0.x86_64.rpm && \
-chmod -R o+w /vagrant/Disk1 && \
+chmod -R u+w /vagrant/Disk1 && \
 rm -rf /vagrant/Disk1 && \
 sudo ln -s /u01/app/oracle /opt/oracle
 


### PR DESCRIPTION
This fixes issue #50.

This pull request adds one line to the Oracle Database 11.2.0.2 box `install.sh` script to grant write permissions on the Oracle XE installer directory (`/vagrant/Disk1`) before removing it.

To validate, `cd` to the OracleDatabase/11.2.0.2 directory, and run `vagrant up`. After the VM is created, Oracle XE should be installed correctly, and the directory `/vagrant/Disk1` should not exist.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>