### PR TITLE
ContainerRegistry: enable Docker proxies during provisioning

### DIFF
--- a/ContainerRegistry/Vagrantfile
+++ b/ContainerRegistry/Vagrantfile
@@ -89,7 +89,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.network "forwarded_port", guest: 5000, host: REGISTRY_BIND
   end
 
-  # Provisioning: install Docker and run registry
+  # Provisioning: install Docker
   config.vm.provision "shell",
     path: "scripts/provision.sh"
+
+  # Provisioning: run registry
+  # We need a separate step to get proxies activated if needed
+  config.vm.provision "shell",
+    path: "scripts/provision-cr.sh"
 end

--- a/ContainerRegistry/scripts/provision-cr.sh
+++ b/ContainerRegistry/scripts/provision-cr.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: June, 2018
+# Author: philippe.vanhaesendonck@oracle.com
+# Description: Installs Docker Engine and runs a registry container
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+echo "Run docker registry"
+docker run \
+        --detach \
+        --restart unless-stopped \
+        --name registry \
+        --publish 5000:5000 \
+        registry:2
+
+echo "Your Registry VM is ready to use!"

--- a/ContainerRegistry/scripts/provision.sh
+++ b/ContainerRegistry/scripts/provision.sh
@@ -25,13 +25,3 @@ usermod -a -G docker vagrant
 # Enable and start Docker
 systemctl enable docker
 systemctl start docker
-
-echo "Run docker registry"
-docker run \
-        --detach \
-        --restart unless-stopped \
-        --name registry \
-        --publish 5000:5000 \
-        registry:2
-
-echo "Your Registry VM is ready to use!"


### PR DESCRIPTION
Fix an issue in the  ContainerRegistry setup: when proxies are used, Docker proxies need to be configured after docker is installed and before the Registry image is pulled.