### PR TITLE
 Kubernetes/ContainerRegistry: use .env files for configuration 

### DIFF
--- a/ContainerRegistry/.env
+++ b/ContainerRegistry/.env
@@ -1,0 +1,20 @@
+# Kubernetes cluster configuration file
+#
+# Requires vagrant-env plugin
+# 
+# This file will be overwritten on updates, it is recommended to make changes
+# in .env.local
+
+# Registry IP on the private VirtualBox lan
+# REGISTRY_IP="192.168.99.253"
+
+# Bind registry port to host port
+# REGISTRY_BIND=5000
+
+# Memory for the VMs (Registry doesn't require much)
+# MEMORY=1024
+
+# Proxies (requires vagrant-proxy plugin)
+# http_proxy=
+# https_proxy=
+# no_proxy=

--- a/ContainerRegistry/.gitignore
+++ b/ContainerRegistry/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/ContainerRegistry/README.md
+++ b/ContainerRegistry/README.md
@@ -23,6 +23,28 @@ Your local container registry is up and running!
 The Vagrantfile can be used _as-is_; there are a couple of parameters you
 can set to tailor the installation to your needs.
 
+### How to configure
+There are several ways to set parameters:
+1. Update the Vagrantfile. This is straightforward; the downside is that you
+will loose changes when you update this repository.
+1. Use environment variables. Might be difficult to remember the parameters
+used when the box was instantiated.
+1. Use the `.env`/`.env.local` files (requires
+[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). Configure
+your Registry by editing the `.env` file; or better copy `.env` to `.env.local`
+and edit the latter one, it won't be overridden when you update this repository
+and it won't mark your git tree as changed (you won't accidentally commit your
+local configuration!)
+
+Parameters are considered in the following order (first one wins):
+1. Environment variables
+1. `.env.local` (if [vagrant-env](https://github.com/gosuri/vagrant-env) plugin
+is installed)
+1. `.env` (if [vagrant-env](https://github.com/gosuri/vagrant-env) plugin
+is installed)
+1. Vagrantfile definitions
+
+### Registry parameters
 - `REGISTRY_IP` (default: 192.168.99.253): the VM will join the VirtualBox
 private network using this IP.
 - `REGISTRY_BIND` (default: undefined): if this variable is defined, Vagrant
@@ -60,6 +82,8 @@ cluster will be fully operational after a `vagrant up`!
 
 ## Optional plugins
 You might want to install the following Vagrant plugin:
+- [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
 - [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VMs if you need to access Internet through proxy. See
 plugin documentation for the configuration.

--- a/ContainerRegistry/Vagrantfile
+++ b/ContainerRegistry/Vagrantfile
@@ -23,12 +23,30 @@ VAGRANTFILE_API_VERSION = "2"
 # Hostname
 NAME = "registry"
 
-# Registry IP on the private VirtualBox lan
-REGISTRY_IP = "192.168.99.253"
-# Bind registry port to host port
-# REGISTRY_BIND = 5000
-# Memory for the VMs (Registry doesn't require much)
-MEMORY = 1024
+# Define constants
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use vagrant-env plugin if available
+  if Vagrant.has_plugin?("vagrant-env")
+    config.env.load('.env.local', '.env') # enable the plugin
+  end
+
+  # Registry IP on the private VirtualBox lan
+  REGISTRY_IP = default_s('REGISTRY_IP', '192.168.99.253')
+  # Bind registry port to host port
+  # REGISTRY_BIND = 5000
+  REGISTRY_BIND = default_s('REGISTRY_BIND', '')
+  # Memory for the VMs (Registry doesn't require much)
+  MEMORY = default_i('MEMORY', 1024)
+end
+
+# Convenience methods
+def default_s(key, default)
+  ENV[key] && ! ENV[key].empty? ? ENV[key] : default
+end
+
+def default_i(key, default)
+  default_s(key, default).to_i
+end
 
 def ensure_scheme(url)
   (url =~ /.*:\/\// ? '' : 'http://') + url
@@ -84,9 +102,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :hosts, :sync_hosts => true
   end
 
-  if defined? REGISTRY_BIND
+  unless REGISTRY_BIND.empty?
     # Bind registry port to host port
-    config.vm.network "forwarded_port", guest: 5000, host: REGISTRY_BIND
+    config.vm.network "forwarded_port", guest: 5000, host: REGISTRY_BIND.to_i
   end
 
   # Provisioning: install Docker

--- a/Kubernetes/.env
+++ b/Kubernetes/.env
@@ -1,0 +1,41 @@
+# Kubernetes cluster configuration file
+#
+# Requires vagrant-env plugin
+# 
+# This file will be overwritten on updates, it is recommended to make changes
+# in .env.local
+
+# Number of worker nodes to provision
+# NB_WORKERS=2
+
+# Use the "Preview" channel for both Docker Engine and Kubernetes
+# USE_PREVIEW=true
+
+# To manage your cluster from the vagrant host, set the following variable
+# to true
+# MANAGE_FROM_HOST=false
+
+# The following will bind the manager default kubernetes proxy port (8001) to
+# the vagrant host
+# BIND_PROXY=true
+
+# Memory for the VMs (2GB)
+# MEMORY=2048
+
+# Local Registry configuration -- Use the following parameters if you have
+# configured a Local Registry
+# Repository and prefix - e.g. for local-registry.example.com:5000/kubernetes:
+# KUBE_REPO="local-registry.example.com:5000"
+# KUBE_PREFIX="/kubernetes"
+
+# Does the registry requires login? If no login is required, the provisioning
+# script will be able to run kubadm-setup on all nodes!
+# KUBE_LOGIN=true
+
+# Does the registry use SSL?
+# KUBE_SSL=true
+
+# Proxies (requires vagrant-proxy plugin)
+# http_proxy=
+# https_proxy=
+# no_proxy=

--- a/Kubernetes/.gitignore
+++ b/Kubernetes/.gitignore
@@ -1,3 +1,4 @@
+.env.local
 admin.conf
 join-command.sh
 local

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -51,6 +51,28 @@ scripts.
 The Vagrantfile can be used _as-is_; there are a couple of parameters you
 can set to tailor the installation to your needs.
 
+### How to configure
+There are several ways to set parameters:
+1. Update the Vagrantfile. This is straightforward; the downside is that you
+will loose changes when you update this repository.
+1. Use environment variables. Might be difficult to remember the parameters
+used when the box was instantiated.
+1. Use the `.env`/`.env.local` files (requires
+[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). Configure
+your cluster by editing the `.env` file; or better copy `.env` to `.env.local`
+and edit the latter one, it won't be overridden when you update this repository
+and it won't mark your git tree as changed (you won't accidentally commit your
+local configuration!)
+
+Parameters are considered in the following order (first one wins):
+1. Environment variables
+1. `.env.local` (if [vagrant-env](https://github.com/gosuri/vagrant-env) plugin
+is installed)
+1. `.env` (if [vagrant-env](https://github.com/gosuri/vagrant-env) plugin
+is installed)
+1. Vagrantfile definitions
+
+### Cluster parameters
 - `NB_WORKERS` (default: 2): the number of worker nodes to provision.
 - `USE_PREVIEW` (default: `true`): when `true`, Vagrant provisioning script
 will use the _Oracle Linux 7 Preview_ and _Add-ons_ channels for both Docker
@@ -108,6 +130,8 @@ local registry in Vagrant.
 
 ## Optional plugins
 You might want to install the following Vagrant plugins:
+- [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
 - [vagrant-hosts](https://github.com/oscar-stack/vagrant-hosts): maintains
 /etc/hosts for the guest VMs;
 - [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -32,6 +32,7 @@
 #
 # Optional plugins:
 #     vagrant-hosts (maintains /etc/hosts for the VMs)
+#     vagrant-env (use .env files for configuration)
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -39,38 +40,62 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-# Number of worker nodes to provision
-NB_WORKERS = 2
-# Use the "Preview" channel for both Docker Engine and Kubernetes
-USE_PREVIEW = true
-# To manage your cluster from the vagrant host, set the following variable
-# to true
-MANAGE_FROM_HOST = false
-# The following will bind the manager default kubernetes proxy port (8001) to
-# the vagrant host
-BIND_PROXY = true
-# Memory for the VMs (2GB)
-MEMORY = 2048
+# Define constants
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use vagrant-env plugin if available
+  if Vagrant.has_plugin?("vagrant-env")
+    config.env.load('.env.local', '.env') # enable the plugin
+  end
 
-# Local Registry configuration -- Use the following parameters if you have
-# configured a Local Registry
-# Repository and prefix - e.g. for local-registry.example.com:5000/kubernetes:
-# KUBE_REPO = "local-registry.example.com:5000"
-# KUBE_PREFIX = "/kubernetes"
-# Does the registry requires login? If no login is required, the provisioning
-# script will be able to run kubadm-setup on all nodes!
-# KUBE_LOGIN = false
-# Does the registry use SSL?
-# KUBE_SSL = false
+  # Number of worker nodes to provision
+  NB_WORKERS = default_i('NB_WORKERS', 2)
+  # Use the "Preview" channel for both Docker Engine and Kubernetes
+  USE_PREVIEW = default_b('USE_PREVIEW', true)
+  # To manage your cluster from the vagrant host, set the following variable
+  # to true
+  MANAGE_FROM_HOST = default_b('MANAGE_FROM_HOST', false)
+  # The following will bind the manager default kubernetes proxy port (8001) to
+  # the vagrant host
+  BIND_PROXY = default_b('BIND_PROXY', true)
+  # Memory for the VMs (2GB)
+  MEMORY = default_i('MEMORY', 2048)
+
+  # Local Registry configuration -- Use the following parameters if you have
+  # configured a Local Registry
+  # Repository and prefix - e.g. for local-registry.example.com:5000/kubernetes:
+  # KUBE_REPO = "local-registry.example.com:5000"
+  # KUBE_PREFIX = "/kubernetes"
+  KUBE_REPO = default_s('KUBE_REPO', '')
+  KUBE_PREFIX = default_s('KUBE_PREFIX', '')
+  # Does the registry requires login? If no login is required, the provisioning
+  # script will be able to run kubadm-setup on all nodes!
+  KUBE_LOGIN = default_b('KUBE_LOGIN', true)
+  # Does the registry use SSL?
+  KUBE_SSL = default_b('KUBE_SSL', true)
+
+end
+
+# Convenience methods
+def default_s(key, default)
+  ENV[key] && ! ENV[key].empty? ? ENV[key] : default
+end
+
+def default_i(key, default)
+  default_s(key, default).to_i
+end
+
+def default_b(key, default)
+  default_s(key, default).to_s.downcase == 'true'
+end
 
 def setup_local_repo (node, vm)
-  if defined? KUBE_REPO
-    registry = KUBE_REPO + ((defined? KUBE_PREFIX) ? KUBE_PREFIX : "")
+  unless KUBE_REPO.empty?
+    registry = KUBE_REPO + KUBE_PREFIX
     vm.provision :shell, inline: <<-SHELL
 	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~/.bashrc
 	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~vagrant/.bashrc
     SHELL
-    if (defined? KUBE_LOGIN) && ! KUBE_LOGIN
+    unless KUBE_LOGIN
       # If registry login is not required, we can run kubeadm
       vm.provision "shell",
         path: "scripts/kubeadm-setup-#{node}.sh",
@@ -181,7 +206,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Provisioning: install Docker and Kubernetes
   args = []
   args.push("--preview") if USE_PREVIEW
-  args.push("--insecure", KUBE_REPO) if (defined? KUBE_SSL) && ! KUBE_SSL
+  args.push("--insecure", KUBE_REPO) unless KUBE_SSL
   config.vm.provision "shell",
     path: "scripts/provision.sh",
     args: args


### PR DESCRIPTION
This PR enables usage of `.env` files for configuration (instead of editing the Vagrantfile).  
It relies the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin.

The plugin is optional, users can still edit the Vagrantfile as before. If the plugin is installed `.env` files are considered and take precedence over the Vagrantfile.

It is recommended to make changes in `.env.local` as this file is not versioned.

Users of the [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf) plugin can also use the `.env` files to store HTTP proxy configuration.

As side-effect of this change, environment variables can also be used to configure boxes. They take precedence over any other methods.