### PR TITLE
K8s: refactor for k8s 1.1.10

### DIFF
--- a/ContainerRegistry/scripts/kubeadm-setup-registry.sh
+++ b/ContainerRegistry/scripts/kubeadm-setup-registry.sh
@@ -12,6 +12,8 @@
 #
 
 Registry="container-registry.oracle.com"
+Repo="kubernetes"
+YumOpts="--disablerepo ol7_developer"
 
 # Parse arguments
 while [ $# -gt 0 ]
@@ -25,6 +27,12 @@ do
       fi
       Registry="$2"
       shift; shift
+      ;;
+    "--dev")
+      # Developper release
+      Repo="kubernetes_developer"
+      YumOpts=""
+      shift
       ;;
     *)
       echo "$0: Invalid parameter"
@@ -42,9 +50,9 @@ then
 fi
 
 echo "$0: Installing kubeadm"
-sudo yum install -y kubeadm
+sudo yum install -y ${YumOpts} kubeadm
 
 echo "$0: Cloning Kubernetes containers"
-/bin/kubeadm-registry.sh --to localhost:5000/kubernetes --from ${Registry}/kubernetes
+/bin/kubeadm-registry.sh --to localhost:5000/kubernetes --from ${Registry}/${Repo}
 
 echo "$0: Clone complete!"

--- a/Kubernetes/.env
+++ b/Kubernetes/.env
@@ -8,8 +8,9 @@
 # Number of worker nodes to provision
 # NB_WORKERS=2
 
-# Use the "Preview" channel for both Docker Engine and Kubernetes
+# Use the "Preview"/"Developer" channels for both Docker Engine and Kubernetes
 # USE_PREVIEW=false
+# USE_DEV=false
 
 # To manage your cluster from the vagrant host, set the following variable
 # to true

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -74,10 +74,14 @@ is installed)
 
 ### Cluster parameters
 - `NB_WORKERS` (default: 2): the number of worker nodes to provision.
-- `USE_PREVIEW` (default: `true`): when `true`, Vagrant provisioning script
-will use the _Oracle Linux 7 Preview_ and _Add-ons_ channels for both Docker
-Engine and Kubernetes (latest version is select by `yum`).  
-Otherwhise it will only use the _Add-ons_ channel.
+- Yum channel parameters. The following 2 parameters can be used to enable the
+_Preview_ and/or _Developer_ channels. These channels are disabled by default
+to install the latest supported version of the Docker Engine and Kubernetes.
+  - `USE_PREVIEW` (default: `false`): when `true`, Vagrant provisioning script
+will enable the _Oracle Linux 7 Preview_ channel.  
+  - `USE_DEV` (default: `false`): when `true`, Vagrant provisioning script
+will enable the _Oracle Linux 7 Developper_ channel.  
+See also [Installing the Developer release of Kubernetes](#installing-the-developer-release-of-kubernetes).
 - `MANAGE_FROM_HOST` (default: `false`): when `true`, Vagrant will bind port
 `6443` from the master node to the host.
 This allows you to manage the cluster from the host itself using the generated
@@ -127,6 +131,14 @@ cluster will be fully operational after a `vagrant up`!
 
 See also the [Container Registry Vagrantfile](../ContainerRegistry) to run a
 local registry in Vagrant.
+
+### Installing the Developer release of Kubernetes
+To install the latest Developer release of Kubernetes you need to enable
+the _Developer_ channel __and__ amend the `KUBE_PREFIX`:
+```ruby
+USE_DEV = true
+KUBE_PREFIX = "/kubernetes_developer"
+```
 
 ## Optional plugins
 You might want to install the following Vagrant plugins:

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -51,6 +51,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   NB_WORKERS = default_i('NB_WORKERS', 2)
   # Use the "Preview" channel for both Docker Engine and Kubernetes
   USE_PREVIEW = default_b('USE_PREVIEW', false)
+  # Use the "Developer" channel for both Docker Engine and Kubernetes
+  USE_DEV = default_b('USE_DEV', false)
   # To manage your cluster from the vagrant host, set the following variable
   # to true
   MANAGE_FROM_HOST = default_b('MANAGE_FROM_HOST', false)
@@ -89,8 +91,9 @@ def default_b(key, default)
 end
 
 def setup_local_repo (node, vm)
-  unless KUBE_REPO.empty?
-    registry = KUBE_REPO + KUBE_PREFIX
+  unless KUBE_REPO.empty? && KUBE_PREFIX.empty?
+    registry = (KUBE_REPO.empty? ? 'container-registry.oracle.com' : KUBE_REPO) + 
+               (KUBE_PREFIX.empty? ? '/kubernetes' : KUBE_PREFIX)
     vm.provision :shell, inline: <<-SHELL
 	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~/.bashrc
 	echo 'export KUBE_REPO_PREFIX="#{registry}"' >> ~vagrant/.bashrc
@@ -206,6 +209,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Provisioning: install Docker and Kubernetes
   args = []
   args.push("--preview") if USE_PREVIEW
+  args.push("--dev") if USE_DEV
   args.push("--insecure", KUBE_REPO) unless KUBE_SSL
   config.vm.provision "shell",
     path: "scripts/provision.sh",

--- a/Kubernetes/scripts/provision.sh
+++ b/Kubernetes/scripts/provision.sh
@@ -12,8 +12,12 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
-# YUM repo selection.
-YumRepos="--disablerepo=ol7_preview"
+# Install the yum-utils package for repo selection
+yum install -y yum-utils
+
+# Disable Preview and Developer channels
+yum-config-manager --disable ol7_preview ol7_developer\* > /dev/null
+
 Insecure=""
 
 # Parse arguments
@@ -21,7 +25,11 @@ while [ $# -gt 0 ]
 do
   case "$1" in
     "--preview")
-      YumRepos="--enablerepo=ol7_preview"
+      yum-config-manager --enable ol7_preview > /dev/null
+      shift
+      ;;
+    "--dev")
+      yum-config-manager --enable ol7_developer > /dev/null
       shift
       ;;
     "--insecure")
@@ -43,7 +51,7 @@ done
 echo "Installing and configuring Docker Engine"
 
 # Install Docker
-yum ${YumRepos} install -y docker-engine btrfs-progs
+yum install -y docker-engine btrfs-progs
 
 # Create and mount a BTRFS partition for docker.
 docker-storage-config -f -s btrfs -d /dev/sdb
@@ -69,7 +77,7 @@ systemctl start docker
 echo "Installing and configuring Kubernetes packages"
 
 # Install Kubernetes packages from the "preview" channel fulfil pre-requisites
-yum ${YumRepos} install -y  kubeadm
+yum install -y  kubeadm
 # Set SeLinux to Permissive
 /usr/sbin/setenforce 0
 sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config


### PR DESCRIPTION
Some refactoring to support the 1.1.10 developer release.

We still install the latest supported release by default (1.1.9), but one can now install 1.1.10 by setting
```ruby
USE_DEV = true
KUBE_PREFIX = "/kubernetes_developer"
```