### PR TITLE
Don't convert end-of-line for shell scripts

### DIFF
--- a/ContainerRegistry/.gitattributes
+++ b/ContainerRegistry/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf

--- a/Kubernetes/.gitattributes
+++ b/Kubernetes/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf


### PR DESCRIPTION
Disable automatic file conversion to DOS type for shell scripts.

Git for windows will automatically convert `lf` to `crlf` when the `core.autocrlf` configuration parameter is set to `true`.

This PR forces unix line termination for shell scripts (`.sh` files)

Addresses #68 