### PR TITLE
Allow configuration of Database 12.2.0.1 box time zone (#33)

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -12,6 +12,7 @@ A vagrant box that provisions Oracle Database automatically, using Vagrant, an O
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
    1. The first time you run this it will provision everything and may take a while. Ensure you have (a good) internet connection as the scripts will update the virtual box to the latest via `yum`.
+   2. The Vagrant file allows for customization, if desired (see [Customization](#customization))
 5. Connect to the database.
 6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
 
@@ -31,3 +32,13 @@ You can reset the password of the Oracle database accounts by executing `/home/o
 * You can `sudo su - oracle` to switch to the oracle user.
 * The Oracle installation path is `/u01/app/oracle/` by default.
 * On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.
+
+### Customization
+You can customize your Oracle environment by amending the environment variables in the `Vagrantfile` file.
+The following can be customized:
+* `ORACLE_PWD`: `auto generated`
+* `SYSTEM_TIMEZONE`: `automatically set (see below)`
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -19,6 +19,18 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "oracle11g-xe-vagrant"
 
+# get host time zone for setting VM time zone, if possible
+# can override in env section below
+offset_sec = Time.now.gmt_offset
+if (offset_sec % (60 * 60)) == 0
+  offset_hr = ((offset_sec / 60) / 60)
+  timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+  SYSTEM_TIMEZONE = 'Etc/GMT' + timezone_suffix
+else
+  # if host time zone isn't an integer hour offset, fall back to UTC
+  SYSTEM_TIMEZONE = 'UTC'
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
@@ -39,5 +51,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 1521, host: 1521
 
   # Provision everything on the first run
-  config.vm.provision "shell", path: "scripts/install.sh"
+  config.vm.provision "shell", path: "scripts/install.sh", env:
+    {
+       "SYSTEM_TIMEZONE"     => SYSTEM_TIMEZONE
+    }
+
 end

--- a/OracleDatabase/11.2.0.2/scripts/install.sh
+++ b/OracleDatabase/11.2.0.2/scripts/install.sh
@@ -29,6 +29,10 @@ echo LC_ALL=en_US.utf-8 >> /etc/environment
 
 echo 'INSTALLER: Locale set'
 
+# set system time zone
+sudo timedatectl set-timezone $SYSTEM_TIMEZONE
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
 echo 'INSTALLER: Oracle directories created'
 
 # install Oracle

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -44,4 +44,8 @@ The following can be customized:
 * `ORACLE_CHARACTERSET`: `AL32UTF8`
 * `ORACLE_EDITION`: `EE` | `SE2`
 * `ORACLE_PWD`: `auto generated`
-* `SYSTEM_TIMEZONE`: `Defaults to host time zone, when host time zone is an integer hour offset from GMT. When host time zone isn't an integer hour offset from GMT (e.g., in India), defaults to UTC. In either case, can override with a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2").`
+* `SYSTEM_TIMEZONE`: `automatically set (see below)`
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -44,4 +44,4 @@ The following can be customized:
 * `ORACLE_CHARACTERSET`: `AL32UTF8`
 * `ORACLE_EDITION`: `EE` | `SE2`
 * `ORACLE_PWD`: `auto generated`
-* `SYSTEM_TIMEZONE`: `default is host time zone; can override with a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2")`
+* `SYSTEM_TIMEZONE`: `Defaults to host time zone, when host time zone is an integer hour offset from GMT. When host time zone isn't an integer hour offset from GMT (e.g., in India), defaults to UTC. In either case, can override with a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2").`

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -44,3 +44,4 @@ The following can be customized:
 * `ORACLE_CHARACTERSET`: `AL32UTF8`
 * `ORACLE_EDITION`: `EE` | `SE2`
 * `ORACLE_PWD`: `auto generated`
+* `SYSTEM_TIMEZONE`: `default is host time zone; can override with a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2")`

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -19,6 +19,12 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "oracle-12201-vagrant"
 
+# get host time zone for setting VM time zone; can override in env section below
+require 'time'
+offset = ((Time.zone_offset(Time.now.zone) / 60) / 60)
+timezone_suffix = offset >= 0 ? "-#{offset.to_s}" : "+#{(-offset).to_s}"
+SYSTEM_TIMEZONE = 'Etc/GMT' + timezone_suffix
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
@@ -47,7 +53,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
        "ORACLE_SID"          => "ORCLCDB",
        "ORACLE_PDB"          => "ORCLPDB1",
        "ORACLE_CHARACTERSET" => "AL32UTF8",
-       "ORACLE_EDITION"      => "EE"
+       "ORACLE_EDITION"      => "EE",
+       "SYSTEM_TIMEZONE"     => SYSTEM_TIMEZONE
     }
 
 end

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -19,11 +19,17 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "oracle-12201-vagrant"
 
-# get host time zone for setting VM time zone; can override in env section below
-require 'time'
-offset = ((Time.zone_offset(Time.now.zone) / 60) / 60)
-timezone_suffix = offset >= 0 ? "-#{offset.to_s}" : "+#{(-offset).to_s}"
-SYSTEM_TIMEZONE = 'Etc/GMT' + timezone_suffix
+# get host time zone for setting VM time zone, if possible
+# can override in env section below
+offset_sec = Time.now.gmt_offset
+if (offset_sec % (60 * 60)) == 0
+  offset_hr = ((offset_sec / 60) / 60)
+  timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+  SYSTEM_TIMEZONE = 'Etc/GMT' + timezone_suffix
+else
+  # if host time zone isn't an integer hour offset, fall back to UTC
+  SYSTEM_TIMEZONE = 'UTC'
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"

--- a/OracleDatabase/12.2.0.1/scripts/install.sh
+++ b/OracleDatabase/12.2.0.1/scripts/install.sh
@@ -25,6 +25,10 @@ echo LC_ALL=en_US.utf-8 >> /etc/environment
 
 echo 'INSTALLER: Locale set'
 
+# set system time zone
+sudo timedatectl set-timezone $SYSTEM_TIMEZONE
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
 # Install Oracle Database prereq and openssl packages
 yum install -y oracle-database-server-12cR2-preinstall openssl
 

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -44,3 +44,8 @@ The following can be customized:
 * `ORACLE_CHARACTERSET`: `AL32UTF8`
 * `ORACLE_EDITION`: `EE` | `SE2`
 * `ORACLE_PWD`: `auto generated`
+* `SYSTEM_TIMEZONE`: `automatically set (see below)`
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).

--- a/OracleDatabase/18.3.0/Vagrantfile
+++ b/OracleDatabase/18.3.0/Vagrantfile
@@ -19,6 +19,18 @@ VAGRANTFILE_API_VERSION = "2"
 # define hostname
 NAME = "oracle-18c-vagrant"
 
+# get host time zone for setting VM time zone, if possible
+# can override in env section below
+offset_sec = Time.now.gmt_offset
+if (offset_sec % (60 * 60)) == 0
+  offset_hr = ((offset_sec / 60) / 60)
+  timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+  SYSTEM_TIMEZONE = 'Etc/GMT' + timezone_suffix
+else
+  # if host time zone isn't an integer hour offset, fall back to UTC
+  SYSTEM_TIMEZONE = 'UTC'
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ol7-latest"
   config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
@@ -47,7 +59,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
        "ORACLE_SID"          => "ORCLCDB",
        "ORACLE_PDB"          => "ORCLPDB1",
        "ORACLE_CHARACTERSET" => "AL32UTF8",
-       "ORACLE_EDITION"      => "EE"
+       "ORACLE_EDITION"      => "EE",
+       "SYSTEM_TIMEZONE"     => SYSTEM_TIMEZONE
     }
 
 end

--- a/OracleDatabase/18.3.0/scripts/install.sh
+++ b/OracleDatabase/18.3.0/scripts/install.sh
@@ -25,6 +25,10 @@ echo LC_ALL=en_US.utf-8 >> /etc/environment
 
 echo 'INSTALLER: Locale set'
 
+# set system time zone
+sudo timedatectl set-timezone $SYSTEM_TIMEZONE
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
 # Install Oracle Database prereq and openssl packages
 yum install -y oracle-database-preinstall-18c openssl
 


### PR DESCRIPTION
This implements the enhancement in Issue #33. By default, the VM time zone is set to the host time zone when the host time zone is an integer hour offset from GMT. When the host time zone is **not** an integer hour offset (e.g., in India), the VM time zone is set to UTC. In either case, a different time zone can be specified either by name (e.g., "America/Los_Angeles") or by an offset from GMT (e.g., "Etc/GMT-2") in the environment section of the `Vagrantfile`.

Changes are:
- In the `Vagrantfile`, add code to determine host time zone. If the host time zone isn't an integer hour offset from GMT, then default to UTC.
- In the `Vagrantfile`, add a variable in the environment section to pass the time zone to `install.sh`
- In `install.sh`, add code to set the VM's time zone using the environment variable passed in from the `Vagrantfile`
- Update `README.md` to describe the new functionality

To validate (destroy the box between tests):
1. Test `Vagrantfile` default (host time zone, whenever possible, or UTC)
    1. Run `vagrant up`. After the box is provisioned, ssh to it and run the `timedatectl` command. If the host time zone is an integer hour offset from GMT, the time zone shown should match the host time zone. If the host time zone is **not** an integer hour offset (e.g., in India), the time zone shown should be UTC.

2. Test using time zone name
    1. Modify the `SYSTEM_TIMEZONE` variable in the env section of the `Vagrantfile` to use a time zone name, e.g., `"SYSTEM_TIMEZONE" => "America/Chicago"`.
    2. Run `vagrant up`. After the box is provisioned, ssh to it and run the `timedatectl` command. The time zone shown should match the time zone specified in the `Vagrantfile`.

3. Test using offset from GMT
    1. Modify the `SYSTEM_TIMEZONE` variable in the env section of the `Vagrantfile` to use an offset from GMT, e.g., `"SYSTEM_TIMEZONE" => "Etc/GMT-6"`.
    2. Run `vagrant up`. After the box is provisioned, ssh to it and run the `timedatectl` command. The time zone shown should match the time zone specified in the `Vagrantfile`.

(For each of these scenarios, one can also connect to the database and run the query `SELECT SYSTIMESTAMP FROM DUAL;`. The date and time returned should match the VM time zone.)

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>