### PR TITLE
Prevent EOL conversion for .sh scripts for DB boxes (#71)

### DIFF
--- a/OracleDatabase/11.2.0.2/.gitattributes
+++ b/OracleDatabase/11.2.0.2/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf

--- a/OracleDatabase/12.2.0.1/.gitattributes
+++ b/OracleDatabase/12.2.0.1/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf

--- a/OracleDatabase/18.3.0/.gitattributes
+++ b/OracleDatabase/18.3.0/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf


### PR DESCRIPTION
This addresses Issue #71. By default, Git for Windows converts Unix line endings (LF) to DOS line endings (CR/LF). This causes the `setPassword.sh` scripts for the 3 Oracle Database boxes to fail when run in the guest.

This PR adds the same `.gitattributes` file that @AmedeeBulle created for the ContainerRegistry and Kubernetes boxes to the 11.2.0.2, 12.2.0.1 and 18.3.0 database boxes. The `.gitattributes` file tells Git to use Unix line endings for `.sh` files. With Unix line endings, the `setPassword.sh` scripts run correctly.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>