### PR TITLE
Merge OL7.6 preview + UEK5 preview vagrant box

### DIFF
--- a/OracleLinux/preview/LICENSE
+++ b/OracleLinux/preview/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 Oracle and/or its affiliates.  All rights reserved.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this
+software, associated documentation and/or data (collectively the "Software"), free of charge and under any and
+all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor
+hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or
+(ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software
+(each a “Larger Work” to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display,
+perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have
+sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must
+be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/OracleLinux/preview/README.md
+++ b/OracleLinux/preview/README.md
@@ -1,1 +1,22 @@
-# Oracle Linux 7 Preview is not actually available
+# ol7u6-preview
+A vagrant box that provisions Oracle Linux 7.6 Preview and UEK5 Preview automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+
+## Prerequisites
+1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+2. Install [Vagrant](https://vagrantup.com/)
+
+## Getting started
+1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
+2. cd vagrant-boxes/OracleLinux/preview
+3. Run `vagrant status` to check Vagrantfile status and possible plugin(s) required
+4. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection!
+   2. The Vagrant file allows for customization.
+5. SSH into the VM either by using `vagrant ssh` 
+   If required, by Vagrantfile you can also setup ssh port forwarding.
+6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
+
+## Other info
+
+* If you need to, you can connect to the machine via `vagrant ssh`.
+* On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.

--- a/OracleLinux/preview/Vagrantfile
+++ b/OracleLinux/preview/Vagrantfile
@@ -1,0 +1,72 @@
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: January, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle Linux virtual machine.
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# define hostname
+NAME = "ol7u6-preview"
+
+unless Vagrant.has_plugin?("vagrant-reload")
+  puts 'Installing vagrant-reload Plugin...'
+  system('vagrant plugin install vagrant-reload')
+end
+
+unless Vagrant.has_plugin?("vagrant-proxyconf")
+  puts 'Installing vagrant-proxyconf Plugin...'
+  system('vagrant plugin install vagrant-proxyconf')
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ol7-latest"
+  config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  config.vm.define NAME
+  
+  config.vm.box_check_update = false
+  
+  # change memory size
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.name = NAME
+  end
+
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    puts "getting Proxy Configuration from Host..."
+    if ENV["http_proxy"]
+      puts "http_proxy: " + ENV["http_proxy"]
+      config.proxy.http     = ENV["http_proxy"]
+    end
+    if ENV["https_proxy"]
+      puts "https_proxy: " + ENV["https_proxy"]
+      config.proxy.https    = ENV["https_proxy"]
+    end
+    if ENV["no_proxy"]
+      config.proxy.no_proxy = ENV["no_proxy"]
+    end
+  end
+
+  # VM hostname
+  config.vm.hostname = NAME
+  
+  # Oracle port forwarding
+  # config.vm.network "forwarded_port", guest: 22, host: 2220
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh"
+  config.vm.provision :reload
+  config.vm.provision "shell", inline: "echo 'INSTALLER: Installation complete, Oracle Linux 7 Update 6 - PREVIEW - ready to use!'"
+
+end

--- a/OracleLinux/preview/scripts/install.sh
+++ b/OracleLinux/preview/scripts/install.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: October, 2018
+# Author: simon.coter@oracle.com
+# Description: Updates Oracle Linux to the latest version
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+echo 'INSTALLER: Started up'
+
+# get up to date
+
+echo 'INSTALLER: Adding Oracle Linux 7 Update 6 Preview Channels'
+
+cat >> /etc/yum.repos.d/public-yum-ol7.repo <<EOF 
+[ol7_u6_developer]
+name=Oracle Linux $releasever Update 6 installation media copy (x86_64)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/6/developer/x86_64/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+
+[ol7_u6_developer_optional]
+name=Oracle Linux $releasever Update 6 optional packages (x86_64)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/optional/developer/x86_64/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+
+EOF
+
+echo 'INSTALLER: Adding UEK5 Preview Channel'
+
+cat >> /etc/yum.repos.d/public-yum-ol7.repo <<EOF
+[ol7_uek5_preview]
+name=Oracle Linux $releasever UEK5 Preview  (x86_64)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/optional/developer/x86_64/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+EOF
+
+echo 'INSTALLER: Getting the system updated'
+yum remove kmod-vboxguest-uek5 -y
+yum upgrade -y
+yum install kernel-uek-devel bzip2 -y
+
+echo 'INSTALLER: Getting VBox Guest Additions Installed'
+
+wget https://www.virtualbox.org/download/testcase/VBoxGuestAdditions_5.2.21-125885.iso -o /dev/null
+mount ./VBoxGuestAdditions_5.2.21-125885.iso /media
+export KERN_VER=`ls /lib/modules |tail -1`
+/media/VBoxLinuxAdditions.run
+
+echo 'INSTALLER: Cleaning up installation files'
+umount /media
+rm -f ./VBoxGuestAdditions_5.2.21-125885.iso
+
+echo 'INSTALLER: System updated'
+
+# fix locale warning
+echo LANG=en_US.utf-8 >> /etc/environment
+echo LC_ALL=en_US.utf-8 >> /etc/environment
+
+echo 'INSTALLER: Locale set'
+
+echo 'INSTALLER: Going to reboot to get updated system'


### PR DESCRIPTION
OL7.6 preview has been announced on Linux Blog and we can now supply the ready-to-run box.