### PR TITLE
Allow running user-defined post-setup scripts (#85)

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -26,6 +26,13 @@ A vagrant box that provisions Oracle Database automatically, using Vagrant, an O
 ## Resetting password
 You can reset the password of the Oracle database accounts by executing `/home/oracle/setPassword.sh <Your new password>`.
 
+## Running scripts after setup
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
 ## Other info
 
 * If you need to, you can connect to the machine via `vagrant ssh`.

--- a/OracleDatabase/11.2.0.2/scripts/install.sh
+++ b/OracleDatabase/11.2.0.2/scripts/install.sh
@@ -67,6 +67,33 @@ sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";
 
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
 echo "ORACLE PASSWORD FOR SYS AND SYSTEM: $ORACLE_PWD";
 
 echo "INSTALLER: Installation complete, database ready to use!";

--- a/OracleDatabase/11.2.0.2/userscripts/.gitignore
+++ b/OracleDatabase/11.2.0.2/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/11.2.0.2/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/11.2.0.2/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,12 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as the vagrant user, which has
+sudo privileges.  SQL scripts will be executed as SYS.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -27,6 +27,13 @@ A vagrant box that provisions Oracle Database automatically, using Vagrant, an O
 ## Resetting password
 You can reset the password of the Oracle database accounts by executing `/home/oracle/setPassword.sh <Your new password>`.
 
+## Running scripts after setup
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
 ## Other info
 
 * If you need to, you can connect to the machine via `vagrant ssh`.

--- a/OracleDatabase/12.2.0.1/scripts/install.sh
+++ b/OracleDatabase/12.2.0.1/scripts/install.sh
@@ -132,6 +132,33 @@ sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";
 
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
 echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
 echo "INSTALLER: Installation complete, database ready to use!";

--- a/OracleDatabase/12.2.0.1/userscripts/.gitignore
+++ b/OracleDatabase/12.2.0.1/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/12.2.0.1/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/12.2.0.1/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,15 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as the vagrant user, which has
+sudo privileges.  SQL scripts will be executed as SYS.  SQL
+scripts will run against the CDB, not the PDB, unless you
+include an ALTER SESSION SET CONTAINER = <pdbname> statement in
+the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -27,6 +27,13 @@ A vagrant box that provisions Oracle Database automatically, using Vagrant, an O
 ## Resetting password
 You can reset the password of the Oracle database accounts by executing `/home/oracle/setPassword.sh <Your new password>`.
 
+## Running scripts after setup
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
 ## Other info
 
 * If you need to, you can connect to the machine via `vagrant ssh`.

--- a/OracleDatabase/18.3.0/scripts/install.sh
+++ b/OracleDatabase/18.3.0/scripts/install.sh
@@ -132,6 +132,33 @@ sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";
 
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
 echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
 echo "INSTALLER: Installation complete, database ready to use!";

--- a/OracleDatabase/18.3.0/userscripts/.gitignore
+++ b/OracleDatabase/18.3.0/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/18.3.0/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/18.3.0/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,15 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as the vagrant user, which has
+sudo privileges.  SQL scripts will be executed as SYS.  SQL
+scripts will run against the CDB, not the PDB, unless you
+include an ALTER SESSION SET CONTAINER = <pdbname> statement in
+the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -27,6 +27,13 @@ A vagrant box that provisions Oracle Database automatically, using Vagrant, an O
 ## Resetting password
 You can reset the password of the Oracle database accounts by switching to the oracle user (`sudo su - oracle`), then executing `/home/oracle/setPassword.sh <Your new password>`.
 
+## Running scripts after setup
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = XEPDB1` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
 ## Other info
 
 * If you need to, you can connect to the machine via `vagrant ssh`.

--- a/OracleDatabase/18.4.0-XE/scripts/install.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/install.sh
@@ -82,6 +82,33 @@ sudo chmod u+x /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";
 
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
 echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
 echo "INSTALLER: Installation complete, database ready to use!";

--- a/OracleDatabase/18.4.0-XE/userscripts/.gitignore
+++ b/OracleDatabase/18.4.0-XE/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/18.4.0-XE/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/18.4.0-XE/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,15 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as the vagrant user, which has
+sudo privileges.  SQL scripts will be executed as SYS.  SQL
+scripts will run against the CDB, not the PDB, unless you
+include an ALTER SESSION SET CONTAINER = XEPDB1 statement in
+the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.


### PR DESCRIPTION
This adds functionality to the 4 Oracle Database boxes to give users the option of running user-defined shell and/or SQL scripts after the database is set up and started. It addresses the enhancement in Issue #85. The functionality is very similar to what's used in the [docker-images](https://github.com/oracle/docker-images) repository.

The following changes are implemented in each of the 4 database boxes (11.2.0.2, 12.2.0.1, 18.3.0, and 18.4.0-XE):
* Add a directory called `userscripts` to contain user-defined scripts.
* Add a file called `put_custom_scripts_here.txt` in the `userscripts` directory. This file contains usage instructions.
* Add a `.gitignore` file in the `userscripts` directory that ignores all files except `put_custom_scripts_here.txt` and `.gitignore` itself.
* Add code to the `install.sh` script to run any `.sh` and/or `.sql` scripts that the user puts in the `userscripts` directory. This code handles both lower- and upper-case file extensions, and works for filenames with spaces in them.
* Add text to the `README.md` file describing the new functionality.

When validating, I'd suggest including script filenames with spaces in them, as well as a mixture of upper- and lower-case file extensions (.sh, .Sh, .SQL, etc.).

I appreciate your consideration! I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>