### PR TITLE
Explicitly set 18c XE box hostname (#91)

### DIFF
--- a/OracleDatabase/18.4.0-XE/Vagrantfile
+++ b/OracleDatabase/18.4.0-XE/Vagrantfile
@@ -44,9 +44,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.name = NAME
   end
 
-  # VM hostname - can't set here, or listener configuration will fail
-  # hostname will default to localhost.localdomain
-  # config.vm.hostname = NAME
+  # VM hostname
+  # must be "localhost", or listener configuration will fail
+  config.vm.hostname = "localhost"
 
   # Oracle port forwarding
   config.vm.network "forwarded_port", guest: 1521, host: 1521


### PR DESCRIPTION
For the Oracle Database 18c XE box, the hostname must be "localhost", or listener configuration will fail. Since "localhost" is the default hostname, the `config.vm.name = NAME` line was originally commented out in the `Vagrantfile`. However, if another Vagrantfile that specifies a hostname is merged with this box's Vagrantfile, the box may end up using that hostname instead of "localhost". (See [https://www.vagrantup.com/docs/vagrantfile/#load-order-and-merging](https://www.vagrantup.com/docs/vagrantfile/#load-order-and-merging).) This seems to be what happened in Issue #91.

This change explicitly sets the hostname for the Oracle Database 18c XE box to "localhost" in the `Vagrantfile`, to reduce the chance of it being overridden by a hostname specified in another Vagrantfile.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>