### PR TITLE
K8s: update for 1.12 release

### DIFF
--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -175,8 +175,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # kubeadm will use the first network interface, which is the NAT interface
     # on VirtualBox and is not routable -- See OraBug 26540925
     master.vm.provision :shell, inline: <<-SHELL
+      # Config file format changed in 1.12
+      # Doing substitutions blindly as only the right ones will match
+      # Pre 1.12 release
       sed -i 's/kubeadm init \\([-$]\\)/kubeadm init --apiserver-advertise-address=192.168.99.100 \\1/' /usr/bin/kubeadm-setup.sh
       sed -i 's/"--kube-subnet-mgr"/"--kube-subnet-mgr", "--iface=eth1"/' /usr/local/share/kubeadm/flannel-ol.yaml
+      # 1.12 release
+      sed -i 's/\\(bindPort: 6443\\)/\\1\\n  advertiseAddress: 192.168.99.100/' /usr/bin/kubeadm-setup.sh
+      sed -i 's/\\(- --kube-subnet-mgr\\)/\\1\\n        - --iface=eth1/' /usr/local/share/kubeadm/flannel-ol.yaml
     SHELL
     if MANAGE_FROM_HOST
       # Add localhost to the list of allowed clients


### PR DESCRIPTION
Changes to support Kubernetes 1.12 (Oracle Container Services for use with Kubernetes 1.1.12)