### PR TITLE
Correct DB box post-setup script instructions (#99)

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -29,7 +29,7 @@ You can reset the password of the Oracle database accounts by executing `/home/o
 ## Running scripts after setup
 You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
 
-Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS.
+Shell scripts will be executed as root. SQL scripts will be executed as SYS.
 
 To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
 

--- a/OracleDatabase/11.2.0.2/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/11.2.0.2/userscripts/put_custom_scripts_here.txt
@@ -4,8 +4,8 @@ and started.  Only shell and SQL scripts will be executed; all
 other files will be ignored.  These scripts are completely
 optional.
 
-Shell scripts will be executed as the vagrant user, which has
-sudo privileges.  SQL scripts will be executed as SYS.
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.
 
 To run scripts in a specific order, prefix the file names with a
 number, e.g., 01_shellscript.sh, 02_tablespaces.sql,

--- a/OracleDatabase/12.1.0.2/README.md
+++ b/OracleDatabase/12.1.0.2/README.md
@@ -30,7 +30,7 @@ You can reset the password of the Oracle database accounts by by switching to th
 ## Running scripts after setup
 You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
 
-Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
 
 To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
 

--- a/OracleDatabase/12.1.0.2/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/12.1.0.2/userscripts/put_custom_scripts_here.txt
@@ -4,11 +4,10 @@ and started.  Only shell and SQL scripts will be executed; all
 other files will be ignored.  These scripts are completely
 optional.
 
-Shell scripts will be executed as the vagrant user, which has
-sudo privileges.  SQL scripts will be executed as SYS.  SQL
-scripts will run against the CDB, not the PDB, unless you
-include an ALTER SESSION SET CONTAINER = <pdbname> statement in
-the script.
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = <pdbname>
+statement in the script.
 
 To run scripts in a specific order, prefix the file names with a
 number, e.g., 01_shellscript.sh, 02_tablespaces.sql,

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -30,7 +30,7 @@ You can reset the password of the Oracle database accounts by executing `/home/o
 ## Running scripts after setup
 You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
 
-Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
 
 To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
 

--- a/OracleDatabase/12.2.0.1/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/12.2.0.1/userscripts/put_custom_scripts_here.txt
@@ -4,11 +4,10 @@ and started.  Only shell and SQL scripts will be executed; all
 other files will be ignored.  These scripts are completely
 optional.
 
-Shell scripts will be executed as the vagrant user, which has
-sudo privileges.  SQL scripts will be executed as SYS.  SQL
-scripts will run against the CDB, not the PDB, unless you
-include an ALTER SESSION SET CONTAINER = <pdbname> statement in
-the script.
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = <pdbname>
+statement in the script.
 
 To run scripts in a specific order, prefix the file names with a
 number, e.g., 01_shellscript.sh, 02_tablespaces.sql,

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -30,7 +30,7 @@ You can reset the password of the Oracle database accounts by executing `/home/o
 ## Running scripts after setup
 You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
 
-Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
 
 To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
 

--- a/OracleDatabase/18.3.0/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/18.3.0/userscripts/put_custom_scripts_here.txt
@@ -4,11 +4,10 @@ and started.  Only shell and SQL scripts will be executed; all
 other files will be ignored.  These scripts are completely
 optional.
 
-Shell scripts will be executed as the vagrant user, which has
-sudo privileges.  SQL scripts will be executed as SYS.  SQL
-scripts will run against the CDB, not the PDB, unless you
-include an ALTER SESSION SET CONTAINER = <pdbname> statement in
-the script.
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = <pdbname>
+statement in the script.
 
 To run scripts in a specific order, prefix the file names with a
 number, e.g., 01_shellscript.sh, 02_tablespaces.sql,

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -30,7 +30,7 @@ You can reset the password of the Oracle database accounts by switching to the o
 ## Running scripts after setup
 You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
 
-Shell scripts will be executed as the vagrant user, which has sudo privileges. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = XEPDB1` statement in the script.
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = XEPDB1` statement in the script.
 
 To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
 

--- a/OracleDatabase/18.4.0-XE/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/18.4.0-XE/userscripts/put_custom_scripts_here.txt
@@ -4,11 +4,10 @@ and started.  Only shell and SQL scripts will be executed; all
 other files will be ignored.  These scripts are completely
 optional.
 
-Shell scripts will be executed as the vagrant user, which has
-sudo privileges.  SQL scripts will be executed as SYS.  SQL
-scripts will run against the CDB, not the PDB, unless you
-include an ALTER SESSION SET CONTAINER = XEPDB1 statement in
-the script.
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = XEPDB1
+statement in the script.
 
 To run scripts in a specific order, prefix the file names with a
 number, e.g., 01_shellscript.sh, 02_tablespaces.sql,


### PR DESCRIPTION
This addresses Issue #99. It corrects the instructions in the `README.md` and `userscripts/put_custom_scripts_here.txt` files for all 5 Oracle Database boxes to state that user-defined post-setup shell scripts are run as root, rather than vagrant.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>