### PR TITLE
Improve tnsnames.ora usability for 18c XE (#104)

### DIFF
--- a/OracleDatabase/18.4.0-XE/scripts/install.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/install.sh
@@ -60,6 +60,19 @@ sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /etc/sysconfig/or
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /etc/sysconfig/oracle-xe-18c.conf
 su -l -c '/etc/init.d/oracle-xe-18c configure'
 
+chmod o+r /opt/oracle/product/18c/dbhomeXE/network/admin/tnsnames.ora
+
+# add tnsnames.ora entry for PDB
+echo 'XEPDB1 =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = XEPDB1)
+    )
+  )
+' >> /opt/oracle/product/18c/dbhomeXE/network/admin/tnsnames.ora
+
 echo 'INSTALLER: Database created'
 
 # enable global port for EM Express


### PR DESCRIPTION
This addresses the enhancement in Issue #104 by adding code to `install.sh` to:
* give read permissions on the `tnsnames.ora` file to all OS users
* add an entry to the `tnsnames.ora` file for the PDB

These changes allow the vagrant user to connect to both the CDB and the PDB using TNS.

To validate:
* run `vagrant up`
* ssh to the box
* run `. oraenv` and enter "XE" for the ORACLE_SID
* verify that both `sqlplus system/<password>@XE` and `sqlplus system/<password>@XEPDB1` successfully connect to the database

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>