### PR TITLE
Support for K8s 1.12.6

### DIFF
--- a/ContainerRegistry/.gitignore
+++ b/ContainerRegistry/.gitignore
@@ -1,1 +1,2 @@
 .env.local
+local

--- a/Kubernetes/.env
+++ b/Kubernetes/.env
@@ -40,3 +40,10 @@
 # http_proxy=
 # https_proxy=
 # no_proxy=
+
+# Force a specific Docker/Kubernetes version (mainly for testing purpose)
+# DOCKER_VERSION=18.09.1.ol
+# K8S_VERSION=1.12.5
+
+# Additional yum channel to consider (e.g. local repo)
+# YUM_REPO=http://my.private.yum/repo/ol7/x86_64/

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -75,6 +75,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Does the registry use SSL?
   KUBE_SSL = default_b('KUBE_SSL', true)
 
+  # Enforce Docker/K8s version (must be in the available/selected yum repos)
+  DOCKER_VERSION = default_s('DOCKER_VERSION', '')
+  K8S_VERSION = default_s('K8S_VERSION', '')
+  # Additional yum channel to consider (e.g. local repo)
+  YUM_REPO = default_s('YUM_REPO', '')
+
 end
 
 # Convenience methods
@@ -215,6 +221,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   args.push("--preview") if USE_PREVIEW
   args.push("--dev") if USE_DEV
   args.push("--insecure", KUBE_REPO) unless KUBE_SSL
+  args.push("--d4r-version", DOCKER_VERSION) unless DOCKER_VERSION == ""
+  args.push("--k8s-version", K8S_VERSION) unless K8S_VERSION == ""
+  args.push("--repo", YUM_REPO) unless YUM_REPO == ""
   config.vm.provision "shell",
     path: "scripts/provision.sh",
     args: args

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -172,25 +172,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # Bind kubernetes default proxy port
       master.vm.network "forwarded_port", guest: 8001, host: 8001
     end
+    # Save options needed for master setup
+    master.vm.provision :shell, inline: <<-SHELL
+      > /root/.kubeadm-options
+    SHELL
     # kubeadm will use the first network interface, which is the NAT interface
     # on VirtualBox and is not routable -- See OraBug 26540925
     master.vm.provision :shell, inline: <<-SHELL
-      # Config file format changed in 1.12
-      # Doing substitutions blindly as only the right ones will match
-      # Pre 1.12 release
-      sed -i 's/kubeadm init \\([-$]\\)/kubeadm init --apiserver-advertise-address=192.168.99.100 \\1/' /usr/bin/kubeadm-setup.sh
-      sed -i 's/"--kube-subnet-mgr"/"--kube-subnet-mgr", "--iface=eth1"/' /usr/local/share/kubeadm/flannel-ol.yaml
-      # 1.12 release
-      sed -i 's/\\(bindPort: 6443\\)/\\1\\n  advertiseAddress: 192.168.99.100/' /usr/bin/kubeadm-setup.sh
+      echo -n " --apiserver-advertise-address 192.168.99.100" >> /root/.kubeadm-options
       sed -i 's/\\(- --kube-subnet-mgr\\)/\\1\\n        - --iface=eth1/' /usr/local/share/kubeadm/flannel-ol.yaml
     SHELL
     if MANAGE_FROM_HOST
       # Add localhost to the list of allowed clients
       master.vm.provision :shell, inline: <<-SHELL
-        # Pre 1.12 release
-        sed -i 's/kubeadm init \\([-$]\\)/kubeadm init --apiserver-cert-extra-sans=localhost,localhost.localdomain,127.0.0.1 \\1/' /usr/bin/kubeadm-setup.sh
-        # 1.12 release
-        sed -i 's/\\(serviceSubnet: .*\\)/\\1\\napiServerCertSANs:\\n- "localhost"\\n- "localhost.localdomain"\\n- "127.0.0.1"/' /usr/bin/kubeadm-setup.sh
+        echo -n " --apiserver-cert-extra-sans localhost,localhost.localdomain,127.0.0.1" >> /root/.kubeadm-options
       SHELL
     end
     if BIND_PROXY

--- a/Kubernetes/scripts/kubeadm-setup-master.sh
+++ b/Kubernetes/scripts/kubeadm-setup-master.sh
@@ -57,7 +57,12 @@ then
 fi
 
 echo "$0: Setup Master node -- be patient!"
-kubeadm-setup.sh up > "${LogFile}" 2>&1
+KubeadmOptions=""
+if [ -r /root/.kubeadm-options ]
+then
+  KubeadmOptions=$(cat /root/.kubeadm-options)
+fi
+kubeadm-setup.sh up ${KubeadmOptions} > "${LogFile}" 2>&1
 
 if [ $? -ne 0 ]
 then

--- a/Kubernetes/scripts/provision.sh
+++ b/Kubernetes/scripts/provision.sh
@@ -19,6 +19,8 @@ yum install -y yum-utils
 yum-config-manager --disable ol7_preview ol7_developer\* > /dev/null
 
 Insecure=""
+D4rVersion=""
+K8sVersion=""
 
 # Parse arguments
 while [ $# -gt 0 ]
@@ -41,6 +43,34 @@ do
       Insecure="$2"
       shift; shift
       ;;
+    "--d4r-version")
+      if [ $# -lt 2 ]
+      then
+        echo "Missing parameter"
+	exit 1
+      fi
+      D4rVersion="-$2"
+      shift; shift
+      ;;
+    "--k8s-version")
+      if [ $# -lt 2 ]
+      then
+        echo "Missing parameter"
+	exit 1
+      fi
+      K8sVersion="-$2"
+      shift; shift
+      ;;
+    "--repo")
+      if [ $# -lt 2 ]
+      then
+        echo "Missing parameter"
+	exit 1
+      fi
+      Repo="$2"
+      yum-config-manager --add-repo "${Repo}"
+      shift; shift
+      ;;
     *)
       echo "Invalid parameter"
       exit 1
@@ -51,7 +81,7 @@ done
 echo "Installing and configuring Docker Engine"
 
 # Install Docker
-yum install -y docker-engine btrfs-progs
+yum install -y docker-engine${D4rVersion} btrfs-progs
 
 # Create and mount a BTRFS partition for docker.
 docker-storage-config -f -s btrfs -d /dev/sdb
@@ -76,8 +106,9 @@ systemctl start docker
 
 echo "Installing and configuring Kubernetes packages"
 
-# Install Kubernetes packages from the "preview" channel fulfil pre-requisites
-yum install -y  kubeadm kubelet kubectl
+# Install Kubernetes packages from the selected channel to fulfil pre-requisites
+yum install -y kubeadm${K8sVersion} kubelet${K8sVersion} kubectl${K8sVersion}
+
 # Set SeLinux to Permissive
 /usr/sbin/setenforce 0
 sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config


### PR DESCRIPTION
**Do not merge this until K8s 1.12.6 is released!**

Background: the `kubeadm-setup.sh` in 1.12.5 script does not properly handle `--apiserver-advertise-address` and `--apiserver-cert-extra-sans` parameters. Our Vagrant setup therefore _patches_ the script as workaround. This issue has been solved (OLCNE-164) and the fix is in 1.12.6 which will be released shortly. We need to update the Vagrant setup accordingly as the workaround won't work anymore when 1.12.6 gets released.

Additionally this PR adds configuration variables to allow installation from local yum repository and to pin Docker or Kubernetes version.
