### PR TITLE
Kubernetes: OCR no longer requires docker login for open source projects

### DIFF
--- a/Kubernetes/.env
+++ b/Kubernetes/.env
@@ -31,7 +31,7 @@
 
 # Does the registry requires login? If no login is required, the provisioning
 # script will be able to run kubadm-setup on all nodes!
-# KUBE_LOGIN=true
+# KUBE_LOGIN=false
 
 # Does the registry use SSL?
 # KUBE_SSL=true

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -12,8 +12,8 @@ worker nodes (2 by default).
 1. Run `vagrant up`
 
 Your cluster is ready!  
-Within the master guest you can check the status of the cluster (as the
-`vagrant` user). E.g.:
+Within the master guest (`vagrant ssh master`) you can check the status of the
+cluster (as the `vagrant` user). E.g.:
 - `kubectl cluster-info`
 - `kubectl get nodes`
 - `kubectl get pods --namespace=kube-system`
@@ -21,7 +21,7 @@ Within the master guest you can check the status of the cluster (as the
 ## If your Container Registry requires authentication
 _Note_: as of October 2019, the Oracle Container Registry does no longer
 require authentication for open source projects. Use these instructions if
-you mirror the contaier images on a registry requiring authentication.
+you mirror the container images on a registry requiring authentication.
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
 1. Change into the `vagrant-boxes/Kubernetes` folder

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -5,22 +5,11 @@ worker nodes (2 by default).
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 1. Install [Vagrant](https://vagrantup.com/)
-1. Sign in to [Oracle Container Registry](https://container-registry.oracle.com)
-and accept the _Oracle Standard Terms and Restrictions_ for the
-_Container Services_ Business Area.
 
 ## Quick start
 1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
 1. Change into the `vagrant-boxes/Kubernetes` folder
-1. Run `vagrant up master; vagrant ssh master`
-1. Within the master guest, run as `root`: <sup>[(\*)](#note-1)</sup>  
-`/vagrant/scripts/kubeadm-setup-master.sh`  
-You will be asked to log in to the Oracle Container Registry
-1. Run `vagrant up worker1; vagrant ssh worker1`
-1. Within the worker1 guest, run as `root`: <sup>[(\*)](#note-1)</sup>  
-`/vagrant/scripts/kubeadm-setup-worker.sh`  
-You will be asked to log in to the Oracle Container Registry
-1. Repeat the last 2 steps for worker2
+1. Run `vagrant up`
 
 Your cluster is ready!  
 Within the master guest you can check the status of the cluster (as the
@@ -29,8 +18,22 @@ Within the master guest you can check the status of the cluster (as the
 - `kubectl get nodes`
 - `kubectl get pods --namespace=kube-system`
 
-<a id="note-1"></a>(\*) If you have a password-less local container registry
-skip steps 4 and 6  (see [Local Registry](#local-registry)).
+## If your Container Registry requires authentication
+_Note_: as of October 2019, the Oracle Container Registry does no longer
+require authentication for open source projects. Use these instructions if
+you mirror the contaier images on a registry requiring authentication.
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
+1. Change into the `vagrant-boxes/Kubernetes` folder
+1. Run `vagrant up master; vagrant ssh master`
+1. Within the master guest, run as `root`:  
+`/vagrant/scripts/kubeadm-setup-master.sh`  
+You will be asked to log in to the Oracle Container Registry
+1. Run `vagrant up worker1; vagrant ssh worker1`
+1. Within the worker1 guest, run as `root`:  
+`/vagrant/scripts/kubeadm-setup-worker.sh`  
+You will be asked to log in to the Oracle Container Registry
+1. Repeat the last 2 steps for worker2
 
 ## About the Vagrantfile
 

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -68,10 +68,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # KUBE_REPO = "local-registry.example.com:5000"
   # KUBE_PREFIX = "/kubernetes"
   KUBE_REPO = default_s('KUBE_REPO', '')
-  KUBE_PREFIX = default_s('KUBE_PREFIX', '')
+  KUBE_PREFIX = default_s('KUBE_PREFIX', '/kubernetes')
   # Does the registry requires login? If no login is required, the provisioning
   # script will be able to run kubadm-setup on all nodes!
-  KUBE_LOGIN = default_b('KUBE_LOGIN', true)
+  KUBE_LOGIN = default_b('KUBE_LOGIN', false)
   # Does the registry use SSL?
   KUBE_SSL = default_b('KUBE_SSL', true)
 
@@ -96,7 +96,7 @@ def default_b(key, default)
   default_s(key, default).to_s.downcase == 'true'
 end
 
-def setup_local_repo (node, vm)
+def setup_repo (node, vm)
   unless KUBE_REPO.empty? && KUBE_PREFIX.empty?
     registry = (KUBE_REPO.empty? ? 'container-registry.oracle.com' : KUBE_REPO) + 
                KUBE_PREFIX
@@ -201,7 +201,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	systemctl daemon-reload
       SHELL
     end
-    setup_local_repo("master", master.vm)
+    setup_repo("master", master.vm)
   end
   # - Workers
   (1..NB_WORKERS).each do |i|
@@ -212,7 +212,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true
       end
-      setup_local_repo("worker", worker.vm)
+      setup_repo("worker", worker.vm)
     end
   end
 


### PR DESCRIPTION
Changes in the K8s boxes as login is no longer needed for the K8s repo.