### PR TITLE
Fix APEX tablespace directory (#163)

### DIFF
--- a/OracleAPEX/scripts/apex.sh
+++ b/OracleAPEX/scripts/apex.sh
@@ -41,7 +41,7 @@ su -l oracle -c "sqlplus / as sysdba <<EOF
 	ALTER DATABASE DATAFILE '$ORACLE_BASE/oradata/$ORACLE_SID/system01.dbf' resize 1024m;
 	ALTER DATABASE DATAFILE '$ORACLE_BASE/oradata/$ORACLE_SID/sysaux01.dbf' resize 1024m;
 	alter session set container=$ORACLE_PDB;
-	CREATE TABLESPACE apex DATAFILE '$ORACLE_BASE/oradata/$ORACLE_SID/apex01.dbf'
+	CREATE TABLESPACE apex DATAFILE '$ORACLE_BASE/oradata/$ORACLE_SID/$ORACLE_PDB/apex01.dbf'
         SIZE 300M AUTOEXTEND ON NEXT 1M;
 	exit;
 EOF"


### PR DESCRIPTION
Create APEX tablespace datafile in PDB's datafile directory (`$ORACLE_BASE/oradata/$ORACLE_SID/$ORACLE_PDB`), instead of CDB's datafile directory (`$ORACLE_BASE/oradata/$ORACLE_SID`).

To validate, build the box and verify that:
- The file `apex01.dbf` is created in the directory `/opt/oracle/oradata/XE/XEPDB1`.
- Logins to APEX work normally.


Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>