### PR TITLE
OLCNE: Install jq (OCI requirement)

### DIFF
--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -205,6 +205,9 @@ parse_args() {
 setup_repos() {
   msg "Configure YUM repos for Oracle Linux Cloud Native Environment"
 
+  # Install jq (OCI requirement)
+  echo_do yum install -y jq
+
   # Install the yum-utils package for repo selection
   echo_do yum install -y yum-utils
 


### PR DESCRIPTION
When Vagrant runs on OCI, yum tries to determine the OCI Region to use the best yum mirror.
This requires `jq`which is installed by default on cloud images but not on the `ol7` vagrant base box.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>