### PR TITLE
Update Oracle Linux versions in READMEs (#174)

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -1,5 +1,5 @@
 # oracle11g-xe-vagrant
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7.3 box and a shell script.
+A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -1,5 +1,5 @@
 # oracle12c-vagrant
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7.3 box and a shell script.
+A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)

--- a/OracleLinux/6/README.md
+++ b/OracleLinux/6/README.md
@@ -1,5 +1,5 @@
 # ol6-vagrant
-A vagrant box that provisions Oracle Linux automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+A vagrant box that provisions Oracle Linux automatically, using Vagrant, an Oracle Linux 6 box and a shell script.
 
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)


### PR DESCRIPTION
Fixes #174 by
* Updating `OracleLinux/6/README.md` to refer to Oracle Linux 6, instead of Oracle Linux 7
* Updating `OracleDatabase/11.2.0.2/README.md` and `OracleDatabase/12.2.0.1/README.md` to refer to Oracle Linux 7, instead of Oracle Linux 7.3

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>