### PR TITLE
Don't abort install on non-zero return code from runInstaller

### DIFF
--- a/OracleDatabase/18.3.0/scripts/install.sh
+++ b/OracleDatabase/18.3.0/scripts/install.sh
@@ -61,7 +61,14 @@ sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.
 sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp && \
 chown oracle:oinstall -R $ORACLE_BASE
 
-su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp"
+su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp" || {
+  ret=$?
+  if [ $ret -ne 6 ]; then
+    echo "Oracle Database installer exited with error!"
+    exit $ret;
+  fi;
+}
+
 $ORACLE_BASE/oraInventory/orainstRoot.sh
 $ORACLE_HOME/root.sh
 rm /vagrant/ora-response/db_install.rsp


### PR DESCRIPTION
This is a fix for #179 
@PaulNeumann, I decided rather than switching off and on again the error handling (`set +e` and `set -e`) to handle the error directly in an inline script. That way a `set -e` may not be forgotten or overlooked in the future when something else is added but the change stays atomic and consistent with the runInstaller command itself.

Would you mind testing this on your end as well?
It works fine on my machine but that's a famous quote that I never want to have my name next to it ;)

Signed-off-by: Gerald Venzl <gerald.venzl@oracle.com>