### PR TITLE
Remove AND lists from DB box install scripts

### DIFF
--- a/OracleDatabase/11.2.0.2/scripts/install.sh
+++ b/OracleDatabase/11.2.0.2/scripts/install.sh
@@ -39,10 +39,10 @@ echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
 echo 'INSTALLER: Oracle directories created'
 
 # install Oracle
-unzip /vagrant/oracle-xe-11.2.0-1.0.x86_64.rpm.zip -d /tmp && \
-sudo rpm -i /tmp/Disk1/oracle-xe-11.2.0-1.0.x86_64.rpm && \
-chmod -R u+w /tmp/Disk1 && \
-rm -rf /tmp/Disk1 && \
+unzip /vagrant/oracle-xe-11.2.0-1.0.x86_64.rpm.zip -d /tmp
+sudo rpm -i /tmp/Disk1/oracle-xe-11.2.0-1.0.x86_64.rpm
+chmod -R u+w /tmp/Disk1
+rm -rf /tmp/Disk1
 sudo ln -s /u01/app/oracle /opt/oracle
 
 echo 'INSTALLER: Oracle software installed'
@@ -58,14 +58,14 @@ rm /tmp/xe.rsp
 echo 'INSTALLER: Database created'
 
 # set environment variables
-echo "export ORACLE_BASE=/u01/app/oracle" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=XE" >> /home/oracle/.bashrc   && \
+echo "export ORACLE_BASE=/u01/app/oracle" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=XE" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
 sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";

--- a/OracleDatabase/12.1.0.2/scripts/install.sh
+++ b/OracleDatabase/12.1.0.2/scripts/install.sh
@@ -38,17 +38,17 @@ yum install -y oracle-rdbms-server-12cR1-preinstall openssl
 echo 'INSTALLER: Oracle preinstall and openssl complete'
 
 # create directories
-mkdir -p $ORACLE_BASE && \
-chown oracle:oinstall -R $ORACLE_BASE && \
-mkdir -p /u01/app && \
+mkdir -p $ORACLE_BASE
+chown oracle:oinstall -R $ORACLE_BASE
+mkdir -p /u01/app
 ln -s $ORACLE_BASE /u01/app/oracle
 
 echo 'INSTALLER: Oracle directories created'
 
 # set environment variables
-echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc   && \
+echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
@@ -69,14 +69,14 @@ case "$ORACLE_EDITION" in
 esac
 
 cp /vagrant/ora-response/db_install.rsp.tmpl /tmp/db_install.rsp
-sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp
 sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /tmp/db_install.rsp
 su -l oracle -c "yes | /tmp/database/runInstaller -silent -showProgress -ignorePrereq -waitforcompletion -responseFile /tmp/db_install.rsp"
 $ORACLE_BASE/oraInventory/orainstRoot.sh
 $ORACLE_HOME/root.sh
 # some files in the installer zips are extracted without write permissions
-chmod -R u+w /tmp/database && \
+chmod -R u+w /tmp/database
 rm -rf /tmp/database
 rm /tmp/db_install.rsp
 
@@ -120,9 +120,9 @@ echo 'INSTALLER: Listener created'
 export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -base64 8`1"}
 
 cp /vagrant/ora-response/dbca.rsp.tmpl /tmp/dbca.rsp
-sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp && \
-sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp && \
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp && \
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /tmp/dbca.rsp
 
 # Create DB
@@ -149,8 +149,8 @@ sudo systemctl enable oracle-rdbms
 sudo systemctl start oracle-rdbms
 echo "INSTALLER: Created and enabled oracle-rdbms systemd's service"
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
-sudo chown oracle:oinstall /home/oracle/setPassword.sh && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
+sudo chown oracle:oinstall /home/oracle/setPassword.sh
 sudo chmod u+x /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";

--- a/OracleDatabase/12.2.0.1/scripts/install.sh
+++ b/OracleDatabase/12.2.0.1/scripts/install.sh
@@ -38,17 +38,17 @@ yum install -y oracle-database-server-12cR2-preinstall openssl
 echo 'INSTALLER: Oracle preinstall and openssl complete'
 
 # create directories
-mkdir -p $ORACLE_BASE && \
-chown oracle:oinstall -R $ORACLE_BASE && \
-mkdir -p /u01/app && \
+mkdir -p $ORACLE_BASE
+chown oracle:oinstall -R $ORACLE_BASE
+mkdir -p /u01/app
 ln -s $ORACLE_BASE /u01/app/oracle
 
 echo 'INSTALLER: Oracle directories created'
 
 # set environment variables
-echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc   && \
+echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
@@ -57,8 +57,8 @@ echo 'INSTALLER: Environment variables set'
 
 unzip /vagrant/linux*122*.zip -d /tmp
 cp /vagrant/ora-response/db_install.rsp.tmpl /tmp/db_install.rsp
-sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp
 sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /tmp/db_install.rsp
 su -l oracle -c "yes | /tmp/database/runInstaller -silent -showProgress -ignorePrereq -waitforcompletion -responseFile /tmp/db_install.rsp"
 $ORACLE_BASE/oraInventory/orainstRoot.sh
@@ -106,9 +106,9 @@ echo 'INSTALLER: Listener created'
 export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -base64 8`1"}
 
 cp /vagrant/ora-response/dbca.rsp.tmpl /tmp/dbca.rsp
-sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp && \
-sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp && \
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp && \
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /tmp/dbca.rsp
 
 # Create DB
@@ -136,7 +136,7 @@ sudo systemctl enable oracle-rdbms
 sudo systemctl start oracle-rdbms
 echo "INSTALLER: Created and enabled oracle-rdbms systemd's service"
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
 sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";

--- a/OracleDatabase/18.3.0/scripts/install.sh
+++ b/OracleDatabase/18.3.0/scripts/install.sh
@@ -38,16 +38,16 @@ yum install -y oracle-database-preinstall-18c openssl
 echo 'INSTALLER: Oracle preinstall and openssl complete'
 
 # create directories
-mkdir -p $ORACLE_HOME && \
-mkdir -p /u01/app && \
+mkdir -p $ORACLE_HOME
+mkdir -p /u01/app
 ln -s $ORACLE_BASE /u01/app/oracle
 
 echo 'INSTALLER: Oracle directories created'
 
 # set environment variables
-echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc   && \
+echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
@@ -56,9 +56,9 @@ echo 'INSTALLER: Environment variables set'
 
 unzip /vagrant/LINUX.X64_180000_db_home.zip -d $ORACLE_HOME/
 cp /vagrant/ora-response/db_install.rsp.tmpl /vagrant/ora-response/db_install.rsp
-sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /vagrant/ora-response/db_install.rsp && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.rsp && \
-sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /vagrant/ora-response/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.rsp
+sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp
 chown oracle:oinstall -R $ORACLE_BASE
 
 su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp" || {
@@ -113,9 +113,9 @@ echo 'INSTALLER: Listener created'
 export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -base64 8`1"}
 
 cp /vagrant/ora-response/dbca.rsp.tmpl /vagrant/ora-response/dbca.rsp
-sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /vagrant/ora-response/dbca.rsp && \
-sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /vagrant/ora-response/dbca.rsp && \
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /vagrant/ora-response/dbca.rsp && \
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /vagrant/ora-response/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /vagrant/ora-response/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /vagrant/ora-response/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /vagrant/ora-response/dbca.rsp
 
 # Create DB
@@ -143,7 +143,7 @@ sudo systemctl enable oracle-rdbms
 sudo systemctl start oracle-rdbms
 echo "INSTALLER: Created and enabled oracle-rdbms systemd's service"
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
 sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";

--- a/OracleDatabase/18.4.0-XE/scripts/install.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/install.sh
@@ -40,9 +40,9 @@ yum install -y oracle-database-preinstall-18c openssl
 echo 'INSTALLER: Oracle preinstall and openssl complete'
 
 # set environment variables
-echo "export ORACLE_BASE=/opt/oracle" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=/opt/oracle/product/18c/dbhomeXE" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=XE" >> /home/oracle/.bashrc && \
+echo "export ORACLE_BASE=/opt/oracle" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=/opt/oracle/product/18c/dbhomeXE" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=XE" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
@@ -56,10 +56,10 @@ echo 'INSTALLER: Oracle software installed'
 export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -base64 8`1"}
 
 # Create database
-mv /etc/sysconfig/oracle-xe-18c.conf /etc/sysconfig/oracle-xe-18c.conf.original && \
-cp /vagrant/ora-response/oracle-xe-18c.conf.tmpl /etc/sysconfig/oracle-xe-18c.conf && \
-chmod g+w /etc/sysconfig/oracle-xe-18c.conf && \
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /etc/sysconfig/oracle-xe-18c.conf && \
+mv /etc/sysconfig/oracle-xe-18c.conf /etc/sysconfig/oracle-xe-18c.conf.original
+cp /vagrant/ora-response/oracle-xe-18c.conf.tmpl /etc/sysconfig/oracle-xe-18c.conf
+chmod g+w /etc/sysconfig/oracle-xe-18c.conf
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /etc/sysconfig/oracle-xe-18c.conf
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /etc/sysconfig/oracle-xe-18c.conf
 su -l -c '/etc/init.d/oracle-xe-18c configure'
 
@@ -92,8 +92,8 @@ sudo systemctl enable oracle-xe-18c
 sudo systemctl start oracle-xe-18c
 echo "INSTALLER: Created and enabled oracle-xe-18c systemd's service"
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
-sudo chown oracle:oinstall /home/oracle/setPassword.sh && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
+sudo chown oracle:oinstall /home/oracle/setPassword.sh
 sudo chmod u+x /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";

--- a/OracleDatabase/19.3.0/scripts/install.sh
+++ b/OracleDatabase/19.3.0/scripts/install.sh
@@ -38,16 +38,16 @@ yum install -y oracle-database-preinstall-19c openssl
 echo 'INSTALLER: Oracle preinstall and openssl complete'
 
 # create directories
-mkdir -p $ORACLE_HOME && \
-mkdir -p /u01/app && \
+mkdir -p $ORACLE_HOME
+mkdir -p /u01/app
 ln -s $ORACLE_BASE /u01/app/oracle
 
 echo 'INSTALLER: Oracle directories created'
 
 # set environment variables
-echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc && \
-echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc && \
-echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc   && \
+echo "export ORACLE_BASE=$ORACLE_BASE" >> /home/oracle/.bashrc
+echo "export ORACLE_HOME=$ORACLE_HOME" >> /home/oracle/.bashrc
+echo "export ORACLE_SID=$ORACLE_SID" >> /home/oracle/.bashrc
 echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 
 echo 'INSTALLER: Environment variables set'
@@ -56,9 +56,9 @@ echo 'INSTALLER: Environment variables set'
 
 unzip /vagrant/LINUX.X64_193000_db_home.zip -d $ORACLE_HOME/
 cp /vagrant/ora-response/db_install.rsp.tmpl /vagrant/ora-response/db_install.rsp
-sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /vagrant/ora-response/db_install.rsp && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.rsp && \
-sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /vagrant/ora-response/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.rsp
+sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp
 chown oracle:oinstall -R $ORACLE_BASE
 
 su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp"
@@ -106,9 +106,9 @@ echo 'INSTALLER: Listener created'
 export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -base64 8`1"}
 
 cp /vagrant/ora-response/dbca.rsp.tmpl /vagrant/ora-response/dbca.rsp
-sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /vagrant/ora-response/dbca.rsp && \
-sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /vagrant/ora-response/dbca.rsp && \
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /vagrant/ora-response/dbca.rsp && \
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /vagrant/ora-response/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /vagrant/ora-response/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /vagrant/ora-response/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /vagrant/ora-response/dbca.rsp
 
 # Create DB
@@ -136,7 +136,7 @@ sudo systemctl enable oracle-rdbms
 sudo systemctl start oracle-rdbms
 echo "INSTALLER: Created and enabled oracle-rdbms systemd's service"
 
-sudo cp /vagrant/scripts/setPassword.sh /home/oracle/ && \
+sudo cp /vagrant/scripts/setPassword.sh /home/oracle/
 sudo chmod a+rx /home/oracle/setPassword.sh
 
 echo "INSTALLER: setPassword.sh file setup";


### PR DESCRIPTION
This fixes #196 by removing the AND (`&&`) lists from the `install.sh` scripts for all 6 of the single-instance database boxes.

To validate, verify that all of the single-instance database boxes build and run correctly.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>