### PR TITLE
Updating OLCNE Vagrant build to support 1.1.0 with Helm and Istio

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # The last matching pattern has the most precedence.
 *                         @gvenzl
+/OLCNE/                   @Djelibeybi
 /OracleDatabase/          @gvenzl
 /OracleLinux/             @scoter-oracle
 /OracleDG/                @rcitton

--- a/OLCNE/.env
+++ b/OLCNE/.env
@@ -1,7 +1,7 @@
 # Oracle Linux Cloud Native Environment configuration file
 #
 # Requires vagrant-env plugin
-# 
+#
 # This file will be overwritten on updates, it is recommended to make changes
 # in .env.local
 
@@ -16,7 +16,7 @@
 # VB_GROUP="OLCNE"
 
 # Create a separate instance for the operator node?
-# The default is to install the Platform API Server and CLI tool on 
+# The default is to install the Platform API Server and CLI tool on
 # the (first) master node
 # STANDALONE_OPERATOR=false
 
@@ -39,7 +39,7 @@
 # Container registry for the Kubernetes module images
 # REGISTRY_K8S='container-registry.oracle.com/olcne'
 
-# Container registry for Oracle Linux Cloud Native Environment images 
+# Container registry for Oracle Linux Cloud Native Environment images
 # REGISTRY_OLCNE='container-registry.oracle.com/olcne'
 
 # Use specific component version (mainly used for development
@@ -52,11 +52,11 @@
 # OLCNE_CLUSTER_NAME="olcne-cluster"
 
 # Deploy the Helm module?
-# DEPLOY_HELM=0
+# DEPLOY_HELM=false
 # HELM_MODULE_NAME="olcne-helm"
 
 # Deploy the Istio module? Requires the Helm module and will set DEPLOY_HELM to 1 if not set.
-# DEPLOY_ISTIO=0
+# DEPLOY_ISTIO=false
 # ISTIO_MODULE_NAME="olcne-istio"
 
 # Override number of masters to deploy

--- a/OLCNE/.env
+++ b/OLCNE/.env
@@ -8,8 +8,9 @@
 # Verbose console
 # VERBOSE=false
 
-# Memory for the VMs (2GB)
-# MEMORY=2048
+# Set vCPU count and memory for the VMs (3GB minimum required for Istio)
+# CPUS=2
+# MEMORY=3072
 
 # Group VirtualBox containers
 # VB_GROUP="OLCNE"
@@ -20,6 +21,7 @@
 # STANDALONE_OPERATOR=false
 
 # Multi-master setup. Deploy 3 masters in HA mode.
+# Will automatically enable STANDALONE_OPERATOR if true
 # MULTI_MASTER=false
 
 # Number of worker nodes to provision
@@ -44,6 +46,18 @@
 # OLCNE_VERSION=
 # K8S_VERSION=
 # NGINX_IMAGE=
+
+# Environment and cluster names
+# OLCNE_ENV_NAME="olcne-env"
+# OLCNE_CLUSTER_NAME="olcne-cluster"
+
+# Deploy the Helm module?
+# DEPLOY_HELM=0
+# HELM_MODULE_NAME="olcne-helm"
+
+# Deploy the Istio module? Requires the Helm module and will set DEPLOY_HELM to 1 if not set.
+# DEPLOY_ISTIO=0
+# ISTIO_MODULE_NAME="olcne-istio"
 
 # Override number of masters to deploy
 # This should not be changed -- for development purpose

--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -4,17 +4,23 @@ This Vagrantfile will deploy and configure the following components:
 - One or more master nodes (one by default, 3 in HA mode)
 - One or more worker nodes (2 by default)
 - An optional operator node for the Oracle Linux Cloud Native Environment
-Platform API Server and Platform CLI tool (default is to install these 
+Platform API Server and Platform CLI tool (default is to install these
 components on the first master node)
 
-All master and worker nodes will have the Oracle Linux Cloud Native 
+If you enable multiple master nodes, an operator node is automatically deployed
+to provide egress routing for the cluster.
+
+All master and worker nodes will have the Oracle Linux Cloud Native
 Environment Platform Agent installed and configured to communicate with the
 Platform API Server on the operator node.
 
 The installation includes the Kubernetes module for Oracle Linux Cloud
-Native Environment which deploys Kubernetes 1.14.8 configured to use
-the CRI-O runtime interface. Two runtime engines are installed, runc and 
+Native Environment which deploys Kubernetes 1.17.4 configured to use
+the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
+
+You may optionally enable the deployment of the Helm and Istio modules. Note
+that enabling the Istio module will automatically enable the Helm module.
 
 _Note:_ Kata Containers requires Intel hardware virtualization support and
 will not work in a VirtualBox guest until nested virtualization support is
@@ -31,7 +37,7 @@ makes configuration much easier
 1. Change into the `vagrant-boxes/OLCNE` folder
 1. Run `vagrant up`
 
-Your Oracle Linux Cloud Native Environment is ready!  
+Your Oracle Linux Cloud Native Environment is ready!
 
 From any master node (e.g. master1) you can check the status of the cluster (as
 the `vagrant` user). E.g.:
@@ -78,11 +84,11 @@ is installed)
 - `VB_GROUP` (default: `OLCNE`): group all VirtualBox VMs under this label.
 
 ### Cluster parameters
-- `STANDALONE_OPERATOR` (default: `false`): create a separate VM for the 
-operator node -- default is to install the operator components on the (first) 
+- `STANDALONE_OPERATOR` (default: `false`): create a separate VM for the
+operator node -- default is to install the operator components on the (first)
 master node.
 - `MULTI_MASTER` (default: `false`): multi-master setup. Deploy 3 masters in
-HA mode.  
+HA mode.
 __Note__: in multi-master mode, to circumvent a networking limitation, the
 default route on master nodes needs to be on the private network interface
 (`eth1`). To achieve this we use a non-master node as default gateway.
@@ -92,14 +98,14 @@ running or you masters will loose Internet connectivity!
 - `NB_WORKERS` (default: 2): number of worker nodes to provision.
 At least one worker node is required.
 - `BIND_PROXY` (default: `false`): bind the kubectl proxy port (8001) from the
-(first) master to the Vagrant host.  
+(first) master to the Vagrant host.
 __Note__: you only need this if you want to expose the kubectl proxy to other
 hosts in your network.
 
 ### Repositories
 - `YUM_REPO` (default: none): additional yum repository to consider
 (e.g. local repo)
-- `OLCNE_DEV` (default: `false`): whether to enable the Oracle Linux Cloud 
+- `OLCNE_DEV` (default: `false`): whether to enable the Oracle Linux Cloud
 Native Environment developer channel.
 - `REGISTRY_K8S` (default: `container-registry.oracle.com/olcne`): container
 registry for the Kubernetes module images.
@@ -107,7 +113,7 @@ registry for the Kubernetes module images.
 registry for other Oracle Linux Cloud Native Environment images (nginx, ...).
 
 ### Advanced Parameters
-Danger zone!  
+Danger zone!
 Mainly used for development.
 
 - The following parameters can be set to use specific component version:

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # Vagrantfile for Oracle Linux Cloud Native Environment
 #
-# Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #
@@ -37,19 +37,27 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.env.load(".env.local", ".env") # enable the plugin
   end
 
-  # Memory for the VMs (2GB)
-  MEMORY = default_i("MEMORY", 2048)
+  # vCPUS (2) and Memory for the VMs (2GB)
+  CPUS = default_i('CPUS', 2)
+  MEMORY = default_i("MEMORY", 3072)
 
   # Group VirtualBox containers
   VB_GROUP = default_s("VB_GROUP", "OLCNE")
 
+  # Multi-master setup. Deploy 3 masters in HA mode.
+  MULTI_MASTER = default_b('MULTI_MASTER', false)
+
   # Separate operator node for the Oracle Linux Cloud Native Environment
   # Platform API Server and Platform Agent (default is to install the
   # components on the (first) master node
-  STANDALONE_OPERATOR = default_b('STANDALONE_OPERATOR', false)
-
-  # Multi-master setup. Deploy 3 masters in HA mode.
-  MULTI_MASTER = default_b('MULTI_MASTER', false)
+  #
+  # If multi-master is enabled, the standalone operator is automatically
+  # enabled for routing purposes
+  if MULTI_MASTER
+    STANDALONE_OPERATOR = true
+  else
+    STANDALONE_OPERATOR = default_b('STANDALONE_OPERATOR', false)
+  end
 
   # Override number of masters to deploy
   # This should not be changed -- for development purpose
@@ -67,11 +75,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Add Oracle Linux Cloud Native Environment developer channel
   OLCNE_DEV = default_b('OLCNE_DEV', false)
 
+  # Set the default OLCNE_ENV_NAME and OLCNE_CLUSTER_NAMEs
+  OLCNE_ENV_NAME = default_s('OLCNE_ENV_NAME', 'olcne-env')
+  OLCNE_CLUSTER_NAME = default_s('OLCNE_CLUSTER_NAME', 'olcne-cluster')
+
   # Container registry for the Kubernetes module images
   REGISTRY_K8S = default_s('REGISTRY_K8S', 'container-registry.oracle.com/olcne')
 
   # Container registry for other Oracle Linux Cloud Native Environment images
   REGISTRY_OLCNE = default_s('REGISTRY_OLCNE', '')
+
+  # Deploy Istio?
+  DEPLOY_ISTIO = default_b('DEPLOY_ISTIO', false)
+
+  # Helm is required to deploy Istio otherwise it's optional
+  if DEPLOY_ISTIO
+    DEPLOY_HELM = true
+  else
+    DEPLOY_HELM = default_b('DEPLOY_HELM', false)
+  end
+
+  HELM_MODULE_NAME = default_s('HELM_MODULE_NAME', 'olcne-helm')
+  ISTIO_MODULE_NAME = default_s('ISTIO_MODULE_NAME', 'olcne-istio')
 
   # Use specific component version (mainly used for development)
   OLCNE_VERSION = default_s('OLCNE_VERSION', '')
@@ -101,10 +126,16 @@ end
 
 def provision_vm(vm, vm_args)
   args = vm_args.clone
+  args.push("--olcne-environment-name", OLCNE_ENV_NAME)
+  args.push("--olcne-cluster-name", OLCNE_CLUSTER_NAME)
   args.push("--multi-master") if MULTI_MASTER
   args.push("--repo", YUM_REPO) unless YUM_REPO == ""
   args.push("--olcne-dev") if OLCNE_DEV
   args.push("--registry-k8s", REGISTRY_K8S) if REGISTRY_K8S
+  args.push("--with-helm") if DEPLOY_HELM
+  args.push("--helm-module-name", HELM_MODULE_NAME) if DEPLOY_HELM
+  args.push("--with-istio") if DEPLOY_ISTIO
+  args.push("--istio-module-name", ISTIO_MODULE_NAME) if DEPLOY_ISTIO
   args.push("--registry-olcne", REGISTRY_OLCNE) if REGISTRY_OLCNE
   args.push("--olcne-version", OLCNE_VERSION) unless OLCNE_VERSION == ""
   args.push("--k8s-version", K8S_VERSION) unless K8S_VERSION == ""
@@ -116,9 +147,9 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # We start from the latest OL 7 Box
-  config.vm.box = "ol7-latest"
-  config.vm.box_url = "https://yum.oracle.com/boxes/oraclelinux/latest/ol7-latest.box"
+  # We start from the latest Oracle Linux 7 Box
+  config.vm.box = "oraclelinux/7"
+  config.vm.box_url = "https://oracle.github.io/vagrant-boxes/boxes/oraclelinux-7.json"
 
   # If we use the vagrant-proxyconf plugin, we should not proxy k8s/local IPs
   # Unfortunately we can't use CIDR with no_proxy, so we have to enumerate and
@@ -161,6 +192,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Provider-specific configuration -- VirtualBox
   config.vm.provider "virtualbox" do |vb|
     vb.memory = MEMORY
+    vb.cpus = CPUS
     vb.customize ["modifyvm", :id, "--groups", "/" + VB_GROUP]
     vb.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
   end
@@ -172,7 +204,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       worker.vm.hostname = "worker#{i}.vagrant.vm"
       ip = 110 + i
       ip_addr = "192.168.99.#{ip}"
-      workers += " #{ip_addr}"
+      workers += "#{ip_addr},"
       worker.vm.network "private_network", ip: ip_addr, auto_config: false
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
@@ -189,7 +221,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       master.vm.hostname = "master#{i}.vagrant.vm"
       ip = 100 + i
       ip_addr = "192.168.99.#{ip}"
-      masters += " #{ip_addr}"
+      masters += "#{ip_addr},"
       master.vm.network "private_network", ip: ip_addr, auto_config: false
       if Vagrant.has_plugin?("vagrant-hosts")
         master.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
@@ -202,8 +234,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       args = ["--master", "--ip-addr", ip_addr]
       if !STANDALONE_OPERATOR && i == 1
         args.push("--operator")
-        args.push("--workers", workers)
-        args.push("--masters", masters)
+        args.push("--workers", workers.chop)
+        args.push("--masters", masters.chop)
         args.push("--nginx-image", NGINX_IMAGE)
       end
       provision_vm(master.vm, args)
@@ -219,8 +251,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         operator.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
       args = ["--operator", "--ip-addr", "192.168.99.100"]
-      args.push("--workers", workers)
-      args.push("--masters", masters)
+      args.push("--workers", workers.chop)
+      args.push("--masters", masters.chop)
       args.push("--nginx-image", NGINX_IMAGE)
       provision_vm(operator.vm, args)
     end

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -30,6 +30,10 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-boxes/boxes"
+BOX_NAME = "oraclelinux/7"
+
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use vagrant-env plugin if available
@@ -147,9 +151,8 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # We start from the latest Oracle Linux 7 Box
-  config.vm.box = "oraclelinux/7"
-  config.vm.box_url = "https://oracle.github.io/vagrant-boxes/boxes/oraclelinux-7.json"
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
 
   # If we use the vagrant-proxyconf plugin, we should not proxy k8s/local IPs
   # Unfortunately we can't use CIDR with no_proxy, so we have to enumerate and

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -646,7 +646,7 @@ deploy_modules() {
 }
 
 #######################################
-# Run fixups
+# Run Kubernetes fixups
 # Globals:
 #   MASTERS
 # Arguments:
@@ -654,20 +654,8 @@ deploy_modules() {
 # Returns:
 #   None
 #######################################
-fixups() {
+k8s_fixups() {
   local node
-
-  msg "Copying admin.conf for vagrant user on master node(s)"
-  for node in ${MASTERS//,/ }; do
-    echo_do ssh "${node}" "\"\
-      mkdir -p ~vagrant/.kube; \
-      cp /etc/kubernetes/admin.conf ~vagrant/.kube/config; \
-      chown -R vagrant: ~vagrant/.kube; \
-      echo 'source <(kubectl completion bash)' >> ~vagrant/.bashrc; \
-      echo 'alias k=kubectl' >> ~vagrant/.bashrc; \
-      echo 'complete -F __start_kubectl k' >> ~vagrant/.bashrc; \
-      \""
-  done
 
   msg "Updating Flannel DaemonSet for Vagrant"
   # This needs to be done on a master node, just pick one from the list
@@ -685,6 +673,32 @@ fixups() {
   msg "Starting kubectl proxy service on master nodes"
   for node in ${MASTERS//,/ }; do
     echo_do ssh "${node}" systemctl start kubectl-proxy.service
+  done
+
+}
+
+#######################################
+# Run config fixups
+# Globals:
+#   MASTERS
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+config_fixups() {
+  local node
+
+  msg "Copying admin.conf for vagrant user on master node(s)"
+  for node in ${MASTERS//,/ }; do
+    echo_do ssh "${node}" "\"\
+      mkdir -p ~vagrant/.kube; \
+      cp /etc/kubernetes/admin.conf ~vagrant/.kube/config; \
+      chown -R vagrant: ~vagrant/.kube; \
+      echo 'source <(kubectl completion bash)' >> ~vagrant/.bashrc; \
+      echo 'alias k=kubectl' >> ~vagrant/.bashrc; \
+      echo 'complete -F __start_kubectl k' >> ~vagrant/.bashrc; \
+      \""
   done
 
 }
@@ -722,8 +736,9 @@ main () {
     certificates
     bootstrap_olcne
     deploy_kubernetes
+    k8s_fixups
     deploy_modules
-    fixups
+    config_fixups
     ready
   fi
 }


### PR DESCRIPTION
This is an initial commit of an update to the OLCNE Vagrant build to support the as-yet-unreleased Oracle Linux Cloud Native Environment 1.1.0 release, including optional deployment of the new Helm and Istio modules.

Things to note:
* `scripts/provision.sh` has had significant changes to conform to ShellCheck.net rules.
* Masquerading is now disabled for OLCNE
* An operator node is mandatory for multi-master deployments (to workaround OLCNE-1028)
* Helm is automatically deployed if Istio is enabled

This is still WIP because the Istio module doesn't always deploy correctly but I'm having a tough time working out why (it may be a resource issue). Also, because 1.1.0 hasn't actually been released yet, it's impossible to test if you don't have insider access to the release bits.

For now, I'd appreciate some sanity reviews for the changes to the `provision.sh` and `.env` in particular. 

Signed-off-by: Avi Miller <avi.miller@oracle.com>