### PR TITLE
Set permissions on the ssh key

### DIFF
--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -435,7 +435,7 @@ passwordless_ssh() {
 	EOF
   # Set permissions
   echo_do chmod 0700 /root/.ssh
-  echo_do chmod 0600 /root/.ssh/authorized_keys
+  echo_do chmod 0600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
   # Last node removes the key
   if [[ ${OPERATOR} == 1 ]]; then
     msg "Removing the shared SSH keypair"


### PR DESCRIPTION
At deployment time, a common ssh key is generated in the `/vagrant` shared folder to enable password-less ssh communication between nodes.
On Windows hosts the file looses its permission which needs to be re-set.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>