### PR TITLE
APEX box - support APEX 20.1 (#223)

### DIFF
--- a/OracleAPEX/scripts/apex.sh
+++ b/OracleAPEX/scripts/apex.sh
@@ -29,7 +29,13 @@ echo "export ORACLE_PDB=$ORACLE_PDB" >> /home/oracle/.bashrc
 
 # Install new apex release
 cd $ORACLE_HOME
-APEX_INSTALL=`ls /vagrant/apex_1*.*.zip |tail -1`
+APEX_INSTALL=$(find /vagrant -maxdepth 1 -name "apex_*.*.zip" -type f | tail -1)
+
+if [[ -z ${APEX_INSTALL} || ! -r "${APEX_INSTALL}" ]]; then
+  echo 'INSTALLER: Could not find APEX installer file. Exiting.'
+  exit 1
+fi
+
 unzip $APEX_INSTALL
 chown -R oracle:oinstall $ORACLE_HOME/apex
 cd -


### PR DESCRIPTION
Fixes #223 by updating the `apex.sh` script to support the APEX 20.1 installer, as well as earlier/later versions. Also eliminates two ShellCheck warnings.

To validate, verify that the box builds and runs correctly with the APEX 20.1 installer, and that the `apex.sh` script exits if the APEX installer is not present.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>