### PR TITLE
Add support for libvirt provider

### DIFF
--- a/ContainerRegistry/Vagrantfile
+++ b/ContainerRegistry/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: June, 2018
 # Author: philippe.vanhaesendonck@oracle.com
@@ -99,6 +99,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.memory = MEMORY
   end
+  config.vm.provider :libvirt do |lv|
+    lv.memory = MEMORY
+    lv.storage :file, :size => '16G', :type => 'qcow2'
+  end
+
 
   config.vm.hostname = NAME + ".vagrant.vm"
   config.vm.network "private_network", ip: REGISTRY_IP

--- a/ContainerRegistry/scripts/provision.sh
+++ b/ContainerRegistry/scripts/provision.sh
@@ -2,7 +2,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: March, 2018
 # Author: philippe.vanhaesendonck@oracle.com
@@ -17,7 +17,7 @@ echo "Installing and configuring Docker Engine"
 yum install -y docker-engine btrfs-progs
 
 # Create and mount a BTRFS partition for docker.
-docker-storage-config -f -s btrfs -d /dev/sdb
+docker-storage-config -f -s btrfs -d /dev/[sv]db
 
 # Add vagrant user to docker group
 usermod -a -G docker vagrant

--- a/DockerEngine/Vagrantfile
+++ b/DockerEngine/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: February, 2018
 # Author: sergio.leunissen@oracle.com
@@ -71,6 +71,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 2048
     v.name = NAME
   end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+    v.storage :file, :size => '16G', :type => 'qcow2'
+  end
+
 
   # VM hostname
   config.vm.hostname = NAME + ".vagrant.vm"

--- a/DockerEngine/scripts/install.sh
+++ b/DockerEngine/scripts/install.sh
@@ -2,12 +2,12 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+#
 # Since: February, 2018
 # Author: sergio.leunissen@oracle.com
 # Description: Installs Docker engine using Btrfs as storage
-# 
+#
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 echo 'Installing and configuring Docker engine'
@@ -18,7 +18,7 @@ yum -y install docker-engine
 # Format spare device as Btrfs
 # Configure Btrfs storage driver
 
-docker-storage-config -s btrfs -d /dev/sdb
+docker-storage-config -s btrfs -d /dev/[sv]db
 
 # Start and enable Docker engine
 systemctl start docker
@@ -33,7 +33,7 @@ chmod a+x /etc/docker
 echo 'Docker engine is ready to use'
 echo 'To get started, on your host, run:'
 echo '  vagrant ssh'
-echo 
+echo
 echo 'Then, within the guest (for example):'
 echo '  docker run -it oraclelinux:6-slim'
 echo

--- a/LAMP/Vagrantfile
+++ b/LAMP/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: April, 2018
 # Author: simon.coter@oracle.com
@@ -42,6 +42,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
   end
 
   # add proxy configuration from host env - optional

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -29,6 +29,7 @@
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
+ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
 # Box metadata location and box name
 BOX_URL = "https://oracle.github.io/vagrant-boxes/boxes"
@@ -196,6 +197,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.cpus = CPUS
     vb.customize ["modifyvm", :id, "--groups", "/" + VB_GROUP]
     vb.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
+  end
+  config.vm.provider :libvirt do |lv|
+    lv.memory = MEMORY
+    lv.cpus = CPUS
+    lv.nested = true
   end
 
   # Workers provisioning

--- a/OracleDatabase/19.3.0/Vagrantfile
+++ b/OracleDatabase/19.3.0/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
@@ -53,6 +53,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
   end
 
   # add proxy configuration from host env - optional

--- a/OracleLinux/6/Vagrantfile
+++ b/OracleLinux/6/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
@@ -42,6 +42,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
   end
 
   # add proxy configuration from host env - optional

--- a/OracleLinux/7/Vagrantfile
+++ b/OracleLinux/7/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
@@ -42,6 +42,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
   end
 
   # add proxy configuration from host env - optional

--- a/OracleLinux/8/Vagrantfile
+++ b/OracleLinux/8/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Oracle and/or its affiliates.
 #
 # Since: January, 2020
 # Author: gerald.venzl@oracle.com
@@ -42,6 +42,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
   end
 
   # add proxy configuration from host env - optional


### PR DESCRIPTION
Add support for the `libvirt` provider for the following boxes:

- OracleLinux: all boxes
- LAMP
- DockerEngine
- ContainerRegistry
- OLCNE
- OracleDatabase/19.3.0

(The above changes have been tested)

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>