### PR TITLE
Update 26ai Free installer RPM checksum

### DIFF
--- a/OracleDatabase/26ai-Free/db_versions.csv
+++ b/OracleDatabase/26ai-Free/db_versions.csv
@@ -1,2 +1,2 @@
-latest,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,346d08a1bc836e97ca74f3c4f1bb3a8d80726480be28991b36b72ee648a06666
-23.26.0,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,346d08a1bc836e97ca74f3c4f1bb3a8d80726480be28991b36b72ee648a06666
+latest,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,4dbbda72e57951297aee67049da5a735ca8a00c606971290d5ff1ddd44d1deb8
+23.26.0,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,4dbbda72e57951297aee67049da5a735ca8a00c606971290d5ff1ddd44d1deb8


### PR DESCRIPTION
Update the SHA256 checksum for the Oracle AI Database 26ai Free installer RPM in `db_versions.csv`. No code changes.

Fixes #558.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>