### PR TITLE
Fix for #556

### DIFF
--- a/OracleRAC/OL7/scripts/setup.sh
+++ b/OracleRAC/OL7/scripts/setup.sh
@@ -582,7 +582,9 @@ echo "-----------------------------------------------------------------"
 echo -e "${INFO}`date +%F' '%T`: Setup the environment variables"
 echo "-----------------------------------------------------------------"
 . /vagrant/config/setup.env
-
+chmod 700 /root
+sed -i 's/^\s*#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+systemctl restart sshd
 
 # ---------------------------------------------------------------------
 # ---------------------------------------------------------------------


### PR DESCRIPTION
This issue is related to the Vagrant box oraclelinux/7 (version 7.9.653), which introduces two changes: 
- The SSH setting PermitRootLogin is set to prohibit-password.
- The /root directory is not writable by default.
The fix is
edit 'scripts/setup.sh' at line 585 and add the following lines:

    chmod 700 /root
    sed -i 's/^\s*#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
    systemctl restart sshd