### PR TITLE
Update 26ai-Free project for 23.26.1

### DIFF
--- a/OracleDatabase/26ai-Free/db_versions.csv
+++ b/OracleDatabase/26ai-Free/db_versions.csv
@@ -1,2 +1,3 @@
-latest,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,4dbbda72e57951297aee67049da5a735ca8a00c606971290d5ff1ddd44d1deb8
+latest,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.1-1.el9.x86_64.rpm,f30a4b847616c3081aa50e9de2efb6a7d42e93ba55258ae0a98744456cd23992
+23.26.1,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.1-1.el9.x86_64.rpm,f30a4b847616c3081aa50e9de2efb6a7d42e93ba55258ae0a98744456cd23992
 23.26.0,https://download.oracle.com/otn-pub/otn_software/db-free/,oracle-ai-database-free-26ai-23.26.0-1.el9.x86_64.rpm,4dbbda72e57951297aee67049da5a735ca8a00c606971290d5ff1ddd44d1deb8


### PR DESCRIPTION
Add 23.26.1 as the latest version in the `db_versions.csv` file for the OracleDatabase/26ai-Free project. No code changes.

Tested with both VirtualBox and libvirt/KVM providers.

Closes #572.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>