### PR TITLE
Add OracleDatabase/26ai project

### DIFF
--- a/OracleDatabase/26ai/.gitattributes
+++ b/OracleDatabase/26ai/.gitattributes
@@ -1,0 +1,2 @@
+*.sh	text eol=lf
+*.cksum	text eol=lf

--- a/OracleDatabase/26ai/.gitignore
+++ b/OracleDatabase/26ai/.gitignore
@@ -1,0 +1,1 @@
+config.local*.yaml

--- a/OracleDatabase/26ai/README.md
+++ b/OracleDatabase/26ai/README.md
@@ -1,0 +1,103 @@
+# oracle-26ai-vagrant
+
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 9 box and a shell script.
+
+## Prerequisites
+
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+
+## Getting started
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
+2. Change into the `vagrant-projects/OracleDatabase/26ai` directory
+3. Download the installation zip file (`LINUX.X64_2326100_db_home.zip`) from OTN into this directory - first time only:
+[https://www.oracle.com/database/technologies/oracle-database-software-downloads.html](https://www.oracle.com/database/technologies/oracle-database-software-downloads.html)
+4. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `dnf`.
+   2. The installation can be customized, if desired (see [Configuration](#configuration)).
+5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
+
+## Connecting to Oracle
+
+The default database connection parameters are:
+
+* Hostname: `localhost`
+* Port: `1521`
+* SID: `ORCLCDB`
+* PDB: `ORCLPDB1`
+* Database passwords are auto-generated and printed on install
+
+These parameters can be customized, if desired (see [Configuration](#configuration)).
+
+## Resetting password
+
+You can reset the password of the Oracle database accounts (SYS, SYSTEM and PDBADMIN only) by switching to the oracle user (`sudo su - oracle`), then executing `/home/oracle/setPassword.sh <Your new password>`.
+
+## Running scripts after setup
+
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
+## Configuration
+
+The `Vagrantfile` can be used _as-is_, without any additional configuration. However, there are several parameters you can set to tailor the installation to your needs.
+
+### How to configure
+
+There are three ways to set parameters:
+
+1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+
+Parameters are considered in the following order (first one wins):
+
+1. Environment variables
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
+4. `Vagrantfile` definitions
+
+### VM parameters
+
+* `VM_NAME` (default: `oracle-26ai-vagrant`): VM name.
+* `VM_MEMORY` (default: `2560`): memory for the VM (in MB, 2560 MB = 2.5 GB).
+* `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+### Oracle Database parameters
+
+* `VM_ORACLE_BASE` (default: `/opt/oracle`): Oracle base directory.
+* `VM_ORACLE_HOME` (default: `/opt/oracle/product/26ai/dbhome_1`): Oracle home directory.
+* `VM_RO_ORACLE_HOME` (default: `false`): Enable read-only Oracle home.
+* `VM_ORACLE_SID` (default: `ORCLCDB`): Oracle SID.
+* `VM_ORACLE_PDB` (default: `ORCLPDB1`): PDB name.
+* `VM_ORACLE_CHARACTERSET` (default: `AL32UTF8`): database character set.
+* `VM_LISTENER_PORT` (default: `1521`): Listener port.
+* `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
+
+## Optional plugin
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
+
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
+## Other info
+
+* If you need to, you can connect to the virtual machine via `vagrant ssh`.
+* You can `sudo su - oracle` to switch to the oracle user.
+* On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.

--- a/OracleDatabase/26ai/Vagrantfile
+++ b/OracleDatabase/26ai/Vagrantfile
@@ -1,0 +1,181 @@
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugin:
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+require 'yaml'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
+BOX_NAME = "oraclelinux/9"
+
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+
+# Define constants
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
+  end
+
+  # VM name
+  VM_NAME = default_s('VM_NAME', 'oracle-26ai-vagrant')
+
+  # Memory for the VM (in MB, 2560 MB = 2.5 GB)
+  VM_MEMORY = default_i('VM_MEMORY', 2560)
+
+  # VM time zone
+  # If not specified, will be set to match host time zone (if possible)
+  VM_SYSTEM_TIMEZONE = default_s('VM_SYSTEM_TIMEZONE', host_tz)
+
+  # Oracle base directory
+  VM_ORACLE_BASE = default_s('VM_ORACLE_BASE', '/opt/oracle')
+
+  # Oracle home directory
+  VM_ORACLE_HOME = default_s('VM_ORACLE_HOME', '/opt/oracle/product/26ai/dbhome_1')
+
+  # Enable read-only Oracle home
+  VM_RO_ORACLE_HOME = default_b('VM_RO_ORACLE_HOME', false)
+
+  # Oracle SID
+  VM_ORACLE_SID = default_s('VM_ORACLE_SID', 'ORCLCDB')
+
+  # PDB name
+  VM_ORACLE_PDB = default_s('VM_ORACLE_PDB', 'ORCLPDB1')
+
+  # Database character set
+  VM_ORACLE_CHARACTERSET = default_s('VM_ORACLE_CHARACTERSET', 'AL32UTF8')
+
+  # Listener port
+  VM_LISTENER_PORT = default_i('VM_LISTENER_PORT', 1521)
+
+  # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+  # If left blank, the password will be generated automatically
+  VM_ORACLE_PWD = default_s('VM_ORACLE_PWD', '')
+end
+
+# Convenience methods
+def default_s(key, default)
+  ENV[key] && ! ENV[key].empty? ? ENV[key] : default
+end
+
+def default_i(key, default)
+  default_s(key, default).to_i
+end
+
+def default_b(key, default)
+  default_s(key, default).to_s.downcase == 'true'
+end
+
+def host_tz
+  # get host time zone for setting VM time zone
+  # if host time zone isn't an integer hour offset from GMT, fall back to UTC
+  offset_sec = Time.now.gmt_offset
+  if (offset_sec % (60 * 60)) == 0
+    offset_hr = ((offset_sec / 60) / 60)
+    timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+    'Etc/GMT' + timezone_suffix
+  else
+    'UTC'
+  end
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
+  config.vm.define VM_NAME
+
+  # Provider-specific configuration
+  config.vm.provider "virtualbox" do |v|
+    v.memory = VM_MEMORY
+    v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
+  end
+
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
+    end
+  end
+
+  # VM hostname
+  config.vm.hostname = VM_NAME
+
+  # Oracle port forwarding
+  config.vm.network "forwarded_port", guest: VM_LISTENER_PORT, host: VM_LISTENER_PORT
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh", env:
+    {
+       "SYSTEM_TIMEZONE"     => VM_SYSTEM_TIMEZONE,
+       "ORACLE_BASE"         => VM_ORACLE_BASE,
+       "ORACLE_HOME"         => VM_ORACLE_HOME,
+       "RO_ORACLE_HOME"      => VM_RO_ORACLE_HOME,
+       "ORACLE_SID"          => VM_ORACLE_SID,
+       "ORACLE_PDB"          => VM_ORACLE_PDB,
+       "ORACLE_CHARACTERSET" => VM_ORACLE_CHARACTERSET,
+       "LISTENER_PORT"       => VM_LISTENER_PORT,
+       "ORACLE_PWD"          => VM_ORACLE_PWD
+    }
+
+end

--- a/OracleDatabase/26ai/config.yaml
+++ b/OracleDatabase/26ai/config.yaml
@@ -1,0 +1,45 @@
+---
+# Oracle AI Database 26ai configuration file
+#
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
+#
+# To change a parameter, uncomment it and set it to the desired value.
+# All commented parameters will retain their default values.
+
+# VM name
+#VM_NAME: 'oracle-26ai-vagrant'
+
+# Memory for the VM (in MB, 2560 MB = 2.5 GB)
+#VM_MEMORY: 2560
+
+# VM time zone
+# If not specified, will be set to match host time zone (if possible)
+# Can use time zone name (e.g., 'America/Los_Angeles')
+# or an offset from GMT (e.g., 'Etc/GMT-2')
+#VM_SYSTEM_TIMEZONE: ''
+
+# Oracle base directory
+#VM_ORACLE_BASE: '/opt/oracle'
+
+# Oracle home directory
+#VM_ORACLE_HOME: '/opt/oracle/product/26ai/dbhome_1'
+
+# Enable read-only Oracle home
+#VM_RO_ORACLE_HOME: false
+
+# Oracle SID
+#VM_ORACLE_SID: 'ORCLCDB'
+
+# PDB name
+#VM_ORACLE_PDB: 'ORCLPDB1'
+
+# Database character set
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
+
+# Listener port
+#VM_LISTENER_PORT: 1521
+
+# Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+# If left blank, the password will be generated automatically
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/26ai/db_installer.cksum
+++ b/OracleDatabase/26ai/db_installer.cksum
@@ -1,0 +1,1 @@
+3314059017 2406058543 /vagrant/LINUX.X64_2326100_db_home.zip

--- a/OracleDatabase/26ai/ora-response/db_install.rsp.tmpl
+++ b/OracleDatabase/26ai/ora-response/db_install.rsp.tmpl
@@ -1,0 +1,12 @@
+oracle.install.responseFileVersion=/oracle/install/rspfmt_dbinstall_response_schema_v23.0.0
+oracle.install.option=INSTALL_DB_SWONLY
+UNIX_GROUP_NAME=dba
+INVENTORY_LOCATION=###INVENTORY_LOCATION###
+ORACLE_BASE=###ORACLE_BASE###
+ORACLE_HOME=###ORACLE_HOME###
+oracle.install.db.InstallEdition=EE
+oracle.install.db.OSDBA_GROUP=dba
+oracle.install.db.OSBACKUPDBA_GROUP=dba
+oracle.install.db.OSDGDBA_GROUP=dba
+oracle.install.db.OSKMDBA_GROUP=dba
+oracle.install.db.OSRACDBA_GROUP=dba

--- a/OracleDatabase/26ai/ora-response/dbca.rsp.tmpl
+++ b/OracleDatabase/26ai/ora-response/dbca.rsp.tmpl
@@ -1,0 +1,20 @@
+responseFileVersion=/oracle/assistants/rspfmt_dbca_response_schema_v23.0.0
+gdbName=###ORACLE_SID###
+sid=###ORACLE_SID###
+databaseConfigType=SI
+createAsContainerDatabase=true
+numberOfPDBs=1
+pdbName=###ORACLE_PDB###
+pdbAdminPassword=###ORACLE_PWD###
+templateName=General_Purpose.dbc
+sysPassword=###ORACLE_PWD###
+systemPassword=###ORACLE_PWD###
+dbsnmpPassword=###ORACLE_PWD###
+storageType=FS
+characterSet=###ORACLE_CHARACTERSET###
+nationalCharacterSet=AL16UTF16
+automaticMemoryManagement=FALSE
+totalMemory=1536
+# Some init.ora parameters - disable auditing to save space, enable FS optimizations
+initParams=audit_trail=none,audit_sys_operations=false,filesystemio_options=setall,commit_logging=batch,commit_wait=nowait
+

--- a/OracleDatabase/26ai/scripts/install.sh
+++ b/OracleDatabase/26ai/scripts/install.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Installs Oracle AI Database software
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# Abort on any error
+set -Eeuo pipefail
+
+echo 'INSTALLER: Started up'
+
+# verify that database installer is present and valid
+echo 'INSTALLER: Verifying database installer file'
+
+db_installer=/vagrant/LINUX.X64_2326100_db_home.zip
+
+[[ $(cksum "$db_installer") == $(< /vagrant/db_installer.cksum) ]] || {
+  cat << EOF
+
+INSTALLER: Database installer file missing or invalid.
+           Destroy this VM (vagrant destroy), then
+           make sure that the database installer file
+           is in the same directory as the Vagrantfile,
+           and that its checksum and file size match
+           the values in the db_installer.cksum file,
+           before running vagrant up again.
+
+EOF
+  exit 1
+}
+
+# get up to date
+dnf upgrade -y
+
+echo 'INSTALLER: System updated'
+
+# fix locale warning
+dnf reinstall -y glibc-common
+echo 'LANG=en_US.utf-8' >> /etc/environment
+echo 'LC_ALL=en_US.utf-8' >> /etc/environment
+
+echo 'INSTALLER: Locale set'
+
+# set system time zone
+timedatectl set-timezone "$SYSTEM_TIMEZONE"
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
+# Install Oracle AI Database preinstall and openssl packages
+dnf install -y oracle-ai-database-preinstall-26ai openssl
+
+echo 'INSTALLER: Oracle preinstall and openssl complete'
+
+# create directories
+mkdir -p "$ORACLE_HOME"
+mkdir -p /u01/app
+ln -s "$ORACLE_BASE" /u01/app/oracle
+inventory_location=$(realpath "$ORACLE_BASE"/../oraInventory)
+mkdir -p "$inventory_location"
+
+echo 'INSTALLER: Oracle directories created'
+
+# set environment variables
+# shellcheck disable=SC2153
+cat >> /home/oracle/.bashrc << EOF
+export ORACLE_BASE=$ORACLE_BASE
+export ORACLE_HOME=$ORACLE_HOME
+export ORACLE_SID=$ORACLE_SID
+export PATH=\$PATH:\$ORACLE_HOME/bin
+EOF
+
+echo 'INSTALLER: Environment variables set'
+
+# Install Oracle
+unzip "$db_installer" -d "$ORACLE_HOME"/
+cp /vagrant/ora-response/db_install.rsp.tmpl /tmp/db_install.rsp
+sed -i -e "s|###INVENTORY_LOCATION###|$inventory_location|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp
+chown oracle:oinstall -R "$ORACLE_BASE" "$inventory_location"
+
+# runInstaller should return 6 (successful with warnings) when prereqs are ignored
+su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /tmp/db_install.rsp" || {
+  ret=$?
+  if [[ $ret -ne 6 ]]; then
+    echo 'Oracle AI Database installer exited with error!'
+    exit $ret;
+  fi;
+}
+
+"$inventory_location"/orainstRoot.sh
+"$ORACLE_HOME"/root.sh
+rm /tmp/db_install.rsp
+
+echo 'INSTALLER: Oracle software installed'
+
+# create sqlnet.ora, listener.ora and tnsnames.ora
+if [[ "${RO_ORACLE_HOME,,}" == 'false' ]]; then
+  network_admin_dir="$ORACLE_HOME"/network/admin
+else
+  su -l oracle -c 'roohctl -enable'
+  network_admin_dir=$("$ORACLE_HOME"/bin/orabasehome)/network/admin
+fi
+
+su -l oracle -c "mkdir -p $network_admin_dir"
+su -l oracle -c "echo 'NAME.DIRECTORY_PATH= (TNSNAMES, EZCONNECT, HOSTNAME)' > $network_admin_dir/sqlnet.ora"
+
+# Listener.ora
+su -l oracle -c "echo 'LISTENER =
+(DESCRIPTION_LIST =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = IPC)(KEY = EXTPROC1))
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))
+  )
+)
+
+DEDICATED_THROUGH_BROKER_LISTENER=ON
+DIAG_ADR_ENABLED = off
+' > $network_admin_dir/listener.ora"
+
+su -l oracle -c "echo '$ORACLE_SID=localhost:$LISTENER_PORT/$ORACLE_SID' > $network_admin_dir/tnsnames.ora"
+# shellcheck disable=SC2153
+su -l oracle -c "echo '$ORACLE_PDB=
+(DESCRIPTION =
+  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))
+  (CONNECT_DATA =
+    (SERVER = DEDICATED)
+    (SERVICE_NAME = $ORACLE_PDB)
+  )
+)' >> $network_admin_dir/tnsnames.ora"
+
+# Start LISTENER
+su -l oracle -c 'lsnrctl start'
+
+echo 'INSTALLER: Listener created'
+
+# Create database
+
+# Auto generate ORACLE PWD if not passed in
+export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -base64 8)1"}
+
+cp /vagrant/ora-response/dbca.rsp.tmpl /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /tmp/dbca.rsp
+
+# Create DB
+su -l oracle -c 'dbca -silent -createDatabase -responseFile /tmp/dbca.rsp'
+
+# Post DB setup tasks
+su -l oracle -c "sqlplus / as sysdba << EOF
+   ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
+   ALTER SYSTEM SET LOCAL_LISTENER = '(ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))' SCOPE=BOTH;
+   ALTER SYSTEM REGISTER;
+   exit
+EOF"
+
+rm /tmp/dbca.rsp
+
+echo 'INSTALLER: Database created'
+
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
+echo 'INSTALLER: Oratab configured'
+
+# configure systemd to start Oracle instance on startup
+cp /vagrant/scripts/oracle-rdbms.service /etc/systemd/system/
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /etc/systemd/system/oracle-rdbms.service
+systemctl daemon-reload
+systemctl enable oracle-rdbms
+systemctl start oracle-rdbms
+echo "INSTALLER: Created and enabled oracle-rdbms systemd service"
+
+cp /vagrant/scripts/setPassword.sh /home/oracle/
+chown oracle:oinstall /home/oracle/setPassword.sh
+chmod u=rwx,go=r /home/oracle/setPassword.sh
+
+echo 'INSTALLER: setPassword.sh file setup'
+
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        # shellcheck disable=SC1090
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD"
+
+echo 'INSTALLER: Installation complete, database ready to use!'

--- a/OracleDatabase/26ai/scripts/oracle-rdbms.service
+++ b/OracleDatabase/26ai/scripts/oracle-rdbms.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Oracle Database(s) and Listener
+Requires=network.target
+
+[Service]
+Type=forking
+Restart=no
+ExecStart=###ORACLE_HOME###/bin/dbstart ###ORACLE_HOME###
+ExecStop=###ORACLE_HOME###/bin/dbshut ###ORACLE_HOME###
+User=oracle
+
+[Install]
+WantedBy=multi-user.target

--- a/OracleDatabase/26ai/scripts/setPassword.sh
+++ b/OracleDatabase/26ai/scripts/setPassword.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets the password for sys, system and pdbadmin
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# Abort on any error
+set -Eeuo pipefail
+
+ORACLE_PWD=$1
+
+sqlplus / as sysdba << EOF
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
+EOF
+
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/26ai/userscripts/.gitignore
+++ b/OracleDatabase/26ai/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/26ai/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/26ai/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,14 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = <pdbname>
+statement in the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.


### PR DESCRIPTION
Adds an OracleDatabase/26ai project, based on the OracleDatabase/21.3.0 project.

Notable changes from the 21.3.0 project:

- Use Oracle Linux 9 instead of Oracle Linux 8
- Use `cksum` instead of `sha256` for verifying the installer zip, to match the installer download page
- Remove code and configuration for EM Express (desupported in 26ai)
- Remove code and configuration for installing Standard Edition (not supported by the installer)
- Add an option to enable a read-only Oracle home (false by default)

Tested with both VirtualBox and libvirt/KVM.

Closes #574.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>