### PR TITLE
Fix OracleDatabase/19.3.0 installation error

### DIFF
--- a/OracleDatabase/19.3.0/scripts/install.sh
+++ b/OracleDatabase/19.3.0/scripts/install.sh
@@ -79,7 +79,15 @@ sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.
 sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /vagrant/ora-response/db_install.rsp
 chown oracle:oinstall -R $ORACLE_BASE
 
-su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp"
+# runInstaller may return 6 (successful with warnings) when prereqs are ignored
+su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /vagrant/ora-response/db_install.rsp" || {
+  ret=$?
+  if [[ $ret -ne 6 ]]; then
+    echo 'Oracle Database installer exited with error!'
+    exit $ret;
+  fi;
+}
+
 $ORACLE_BASE/oraInventory/orainstRoot.sh
 $ORACLE_HOME/root.sh
 rm /vagrant/ora-response/db_install.rsp


### PR DESCRIPTION
Add code to the `install.sh` script to allow the script to continue if `runInstaller` exits with exit code 6 (successful with warnings). The code added is the same as the code used in the 18.3.0, 21.3.0 and 26ai projects.

Although this issue hasn't been reported before, if it can happen on one host, it can probably happen on other hosts, too.

Tested with both VirtualBox and libvirt providers.

Fixes #577

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>